### PR TITLE
Add GitHub CLI to dev container and use env_file for secrets

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   app:
+    env_file: ../.env
     build:
       context: ..
       dockerfile: Dockerfile
@@ -12,7 +13,6 @@ services:
       - repos:/repos
     command: sleep infinity
     environment:
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - DATABASE_URL=postgresql://compiler:compiler@db:5432/compiler
       - SHELL=/bin/bash
     depends_on:

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ TOKEN_ENCRYPTION_KEY=
 
 # Public URL (optional, for SSO/SAML when behind a reverse proxy or custom domain)
 # PUBLIC_URL=https://compiler.thelookoutway.net
+
+# GitHub personal access token (for pushing branches and creating PRs from devcontainer)
+# Create at: GitHub > Settings > Developer settings > Personal access tokens
+# GH_TOKEN=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:20-alpine AS development-dependencies-env
-RUN apk add --no-cache git bash curl ripgrep \
+RUN apk add --no-cache git bash curl ripgrep openssh-client github-cli \
     && curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared \
     && chmod +x /usr/local/bin/cloudflared
 COPY . /app


### PR DESCRIPTION
## Summary
- Install `github-cli` and `openssh-client` in the dev container Dockerfile for Git/GitHub operations
- Switch from individual environment variable declarations to `env_file` in docker-compose, simplifying secret management
- Add `GH_TOKEN` to `.env.example` for GitHub authentication from within the devcontainer