### PR TITLE
Prefill prompt after onboarding

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext, useNavigate } from "react-router";
+import { Form, redirect, useOutletContext, useNavigate, useSearchParams } from "react-router";
 import { useRef, useState, useCallback } from "react";
 import type { Route } from "./+types/home";
 import type { AppContext } from "./app-layout";
@@ -100,7 +100,8 @@ const suggestedPrompts = [
 ];
 
 function HomePromptInput({ hasStorageConfig, activeProjectId }: { hasStorageConfig: boolean; activeProjectId?: string }) {
-  const [input, setInput] = useState("");
+  const [searchParams] = useSearchParams();
+  const [input, setInput] = useState(searchParams.get("prompt") || "");
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const formRef = useRef<HTMLFormElement>(null);
   const blobIdsInputRef = useRef<HTMLInputElement>(null);

--- a/app/routes/onboarding.github.test.ts
+++ b/app/routes/onboarding.github.test.ts
@@ -26,7 +26,7 @@ vi.mock("~/lib/appMode.server", () => ({
 }));
 
 vi.mock("~/lib/clone.server", () => ({
-  clonePublicRepository: vi.fn(),
+  clonePublicRepository: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -126,6 +126,49 @@ describe("onboarding.github action", () => {
     expect(result).toEqual({ error: "Use the GitHub App install flow" });
     expect(getInstallationAccessToken).not.toHaveBeenCalled();
     expect(saveInstallation).not.toHaveBeenCalled();
+  });
+
+  it("rejects custom repo with empty URL", async () => {
+    const request = buildActionRequest({ repos: "custom", customRepo: "" });
+    const result = await callAction(request);
+    expect(result).toEqual({ error: "Please enter a repository URL" });
+  });
+
+  it("rejects custom repo with invalid URL", async () => {
+    const request = buildActionRequest({ repos: "custom", customRepo: "not-a-url" });
+    const result = await callAction(request);
+    expect(result).toEqual({ error: "Please enter a valid GitHub repository URL (e.g. https://github.com/owner/repo)" });
+  });
+
+  it("rejects custom repo that does not exist on GitHub", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, { status: 404 })
+    );
+    const request = buildActionRequest({ repos: "custom", customRepo: "https://github.com/owner/nonexistent" });
+    const result = await callAction(request);
+    expect(result).toEqual({ error: "Repository not found. Check the URL and make sure it's a public repository." });
+    fetchSpy.mockRestore();
+  });
+
+  it("rejects custom repo that is private", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ private: true }), { status: 200 })
+    );
+    const request = buildActionRequest({ repos: "custom", customRepo: "https://github.com/owner/private-repo" });
+    const result = await callAction(request);
+    expect(result).toEqual({ error: "This is a private repository. Only public repositories are supported here." });
+    fetchSpy.mockRestore();
+  });
+
+  it("accepts valid public custom repo", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ private: false }), { status: 200 })
+    );
+    const request = buildActionRequest({ repos: "custom", customRepo: "https://github.com/owner/public-repo" });
+    const result = await callAction(request);
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(302);
+    fetchSpy.mockRestore();
   });
 
   it("allows link_installation in self-hosted mode", async () => {

--- a/app/routes/onboarding.project.tsx
+++ b/app/routes/onboarding.project.tsx
@@ -143,7 +143,7 @@ export async function action({ request }: Route.ActionArgs) {
     getOrCreateSandbox(projectId, user.organization.id).catch((err) =>
       console.error("[onboarding] Background sandbox provision failed:", err)
     );
-    return redirect("/");
+    return redirect("/?prompt=What+does+this+project+do+and+what's+changed+recently%3F");
   }
 
   return redirect("/onboarding/syncing");

--- a/app/routes/onboarding.syncing.tsx
+++ b/app/routes/onboarding.syncing.tsx
@@ -101,7 +101,7 @@ export default function OnboardingSyncing({ loaderData }: Route.ComponentProps) 
 
         {allDone ? (
           <Link
-            to="/"
+            to="/?prompt=What+does+this+project+do+and+what's+changed+recently%3F"
             className="block w-full bg-neutral-900 dark:bg-neutral-100 text-white dark:text-neutral-900 font-medium rounded-lg px-4 py-3 hover:bg-neutral-800 dark:hover:bg-neutral-200 transition-colors text-center"
           >
             Continue


### PR DESCRIPTION
- Home page accepts a ?prompt= URL param to prefill the input
- After onboarding, redirect with a default prompt: "What does this project do and what's changed recently?"
- Capitalize default project name when derived from repo name
- Add tests for custom repo URL validation in onboarding action