### PR TITLE
Hide model selector in SaaS mode

### DIFF
--- a/app/components/conversation-layout.tsx
+++ b/app/components/conversation-layout.tsx
@@ -21,6 +21,7 @@ interface ConversationLayoutProps {
   showHeaderBorder?: boolean;
   projects?: ProjectMeta[];
   activeProject?: ProjectMeta | null;
+  saasMode?: boolean;
 }
 
 export function ConversationLayout({
@@ -39,6 +40,7 @@ export function ConversationLayout({
   showHeaderBorder = true,
   projects = [],
   activeProject = null,
+  saasMode = false,
 }: ConversationLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [currentModel, setCurrentModel] = useState(
@@ -124,11 +126,15 @@ export function ConversationLayout({
                 />
               </svg>
             </button>
-            <ModelSelector
-              availableModels={availableModels}
-              currentModel={currentModel}
-              onModelChange={handleModelChange}
-            />
+            {saasMode ? (
+              <span className="text-neutral-900 dark:text-neutral-100 text-lg">Compiler</span>
+            ) : (
+              <ModelSelector
+                availableModels={availableModels}
+                currentModel={currentModel}
+                onModelChange={handleModelChange}
+              />
+            )}
           </div>
           {headerRight && (
             <div className="flex items-center">

--- a/app/routes/app-layout.tsx
+++ b/app/routes/app-layout.tsx
@@ -131,6 +131,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     hasStorageConfig,
     projects: projectsList,
     activeProject,
+    saasMode: isSaas(),
   };
 }
 
@@ -159,6 +160,7 @@ export interface AppContext {
   hasStorageConfig: boolean;
   projects: ProjectMeta[];
   activeProject: ProjectMeta | null;
+  saasMode: boolean;
 }
 
 export default function AppLayout({ loaderData }: Route.ComponentProps) {
@@ -176,6 +178,7 @@ export default function AppLayout({ loaderData }: Route.ComponentProps) {
     hasStorageConfig: loaderData.hasStorageConfig,
     projects: loaderData.projects,
     activeProject: loaderData.activeProject,
+    saasMode: loaderData.saasMode,
   };
 
   return <Outlet context={context} />;

--- a/app/routes/conversation.tsx
+++ b/app/routes/conversation.tsx
@@ -175,6 +175,7 @@ export default function Conversation({ loaderData }: Route.ComponentProps) {
     hasStorageConfig,
     projects,
     activeProject,
+    saasMode,
   } = useOutletContext<AppContext>();
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const initialPrompt = searchParams.get("prompt");
@@ -262,6 +263,7 @@ export default function Conversation({ loaderData }: Route.ComponentProps) {
       userPreferredModel={userPreferredModel}
       projects={projects}
       activeProject={activeProject}
+      saasMode={saasMode}
     >
       <div className="flex flex-col h-full">
           <div className="flex-1 min-h-0">

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -62,6 +62,7 @@ export default function Home() {
     hasStorageConfig,
     projects,
     activeProject,
+    saasMode,
   } = useOutletContext<AppContext>();
 
   return (
@@ -79,6 +80,7 @@ export default function Home() {
       showHeaderBorder={false}
       projects={projects}
       activeProject={activeProject}
+      saasMode={saasMode}
     >
       {impersonating ? (
         <ImpersonatingView name={impersonating.name} />


### PR DESCRIPTION
In SaaS mode the model is fixed in the config, so showing a model name or selector in the conversation header is misleading. Replace it with a plain "Compiler" wordmark when APP_MODE=saas.