### PR TITLE
Set Anthropic effort to xhigh

### DIFF
--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -837,6 +837,7 @@ describe("api.agent action", () => {
       const streamArgs = mockStreamText.mock.calls[0][0];
       expect(streamArgs.providerOptions).toEqual({
         anthropic: {
+          effort: "xhigh",
           contextManagement: {
             edits: [
               {
@@ -856,7 +857,7 @@ describe("api.agent action", () => {
       });
     });
 
-    it("does not pass providerOptions when compactionEnabled is false", async () => {
+    it("passes effort but no contextManagement when compactionEnabled is false", async () => {
       getAgentConfig.mockResolvedValue({
         model: "mock-model",
         modelId: "claude-sonnet-4-6",
@@ -873,7 +874,9 @@ describe("api.agent action", () => {
       await callAction(request);
 
       const streamArgs = mockStreamText.mock.calls[0][0];
-      expect(streamArgs.providerOptions).toBeUndefined();
+      expect(streamArgs.providerOptions).toEqual({
+        anthropic: { effort: "xhigh" },
+      });
     });
 
     it("includes contextManagement regardless of promptCachingEnabled", async () => {
@@ -896,6 +899,7 @@ describe("api.agent action", () => {
       const streamArgs = mockStreamText.mock.calls[0][0];
       expect(streamArgs.providerOptions).toEqual({
         anthropic: {
+          effort: "xhigh",
           contextManagement: {
             edits: [
               {

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -226,27 +226,30 @@ export async function action({ request }: Route.ActionArgs) {
           ),
         })
       : undefined,
-    providerOptions: compactionEnabled
-      ? {
-          anthropic: {
-            contextManagement: {
-              edits: [
-                {
-                  type: "clear_tool_uses_20250919",
-                  trigger: { type: "input_tokens", value: 500000 },
-                  keep: { type: "tool_uses", value: 5 },
-                  clearToolInputs: true,
-                },
-                {
-                  type: "compact_20260112",
-                  trigger: { type: "input_tokens", value: 650000 },
-                  instructions: compactionInstructions,
-                },
-              ],
-            },
-          },
-        }
-      : undefined,
+    providerOptions: {
+      anthropic: {
+        effort: "xhigh",
+        ...(compactionEnabled
+          ? {
+              contextManagement: {
+                edits: [
+                  {
+                    type: "clear_tool_uses_20250919",
+                    trigger: { type: "input_tokens", value: 500000 },
+                    keep: { type: "tool_uses", value: 5 },
+                    clearToolInputs: true,
+                  },
+                  {
+                    type: "compact_20260112",
+                    trigger: { type: "input_tokens", value: 650000 },
+                    instructions: compactionInstructions,
+                  },
+                ],
+              },
+            }
+          : {}),
+      },
+    },
     experimental_transform: smoothStream(),
     stopWhen: stepCountIs(50),
     abortSignal: request.signal,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "compiler",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.63",
-        "@ai-sdk/anthropic": "^3.0.41",
+        "@ai-sdk/anthropic": "^3.0.71",
         "@ai-sdk/react": "^3.0.83",
         "@e2b/code-interpreter": "^2.3.3",
         "@node-saml/node-saml": "^5.1.0",
@@ -65,6 +65,22 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.46",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.46.tgz",
+      "integrity": "sha512-zXJPiNHaIiQ6XUqLeSYZ3ZbSzjqt1pNWEUf2hlkXlmmw8IF8KI0ruuGaDwKCExmtuNRf0E4TDxhsc9wRgWTzpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider-utils": {
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
@@ -83,13 +99,13 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.46",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.46.tgz",
-      "integrity": "sha512-zXJPiNHaIiQ6XUqLeSYZ3ZbSzjqt1pNWEUf2hlkXlmmw8IF8KI0ruuGaDwKCExmtuNRf0E4TDxhsc9wRgWTzpw==",
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15"
+        "@ai-sdk/provider-utils": "4.0.23"
       },
       "engines": {
         "node": ">=18"
@@ -99,9 +115,9 @@
       }
     },
     "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
-      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.63",
-    "@ai-sdk/anthropic": "^3.0.41",
+    "@ai-sdk/anthropic": "^3.0.71",
     "@ai-sdk/react": "^3.0.83",
     "@e2b/code-interpreter": "^2.3.3",
     "@node-saml/node-saml": "^5.1.0",


### PR DESCRIPTION
Compiler runs long agentic tool loops on Opus 4.7. xhigh is the effort level Anthropic positions for sustained agentic work and is Opus-4.7 exclusive; max is targeted at frontier reasoning problems and would spend tokens we do not need for codebase Q&A.

Bumps @ai-sdk/anthropic to 3.0.71 — earlier versions did not include xhigh in the effort enum and would reject the value at request time.