### PR TITLE
Hide Authentication settings in SaaS mode

### DIFF
--- a/app/routes/settings-layout.tsx
+++ b/app/routes/settings-layout.tsx
@@ -21,7 +21,7 @@ const TABS = [
   { label: "Account", path: "/settings", adminOnly: false, selfHostedOnly: false },
   { label: "AI Provider", path: "/settings/ai-provider", adminOnly: true, selfHostedOnly: true },
   { label: "Audit Log", path: "/settings/audit-log", adminOnly: true, selfHostedOnly: false },
-  { label: "Authentication", path: "/settings/authentication", adminOnly: true, selfHostedOnly: false },
+  { label: "Authentication", path: "/settings/authentication", adminOnly: true, selfHostedOnly: true },
   { label: "GitHub", path: "/settings/github", adminOnly: true, selfHostedOnly: false },
   { label: "Organization", path: "/settings/organization", adminOnly: true, selfHostedOnly: false },
   { label: "Projects", path: "/settings/projects", adminOnly: true, selfHostedOnly: false },

--- a/app/routes/settings.authentication.tsx
+++ b/app/routes/settings.authentication.tsx
@@ -6,8 +6,13 @@ import { canManageOrganization } from "~/lib/permissions";
 import { getSSOConfig, saveSSOConfig, generateSPMetadata } from "~/lib/saml.server";
 import { getPublicBaseUrl } from "~/lib/url.server";
 import { logAuditEvent } from "~/lib/audit.server";
+import { isSaas } from "~/lib/appMode.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
+  if (isSaas()) {
+    throw redirect("/settings");
+  }
+
   const user = await requireActiveAuth(request);
 
   if (!canManageOrganization(user.membership?.role)) {


### PR DESCRIPTION
In SaaS mode, identity is managed by the operator. Exposing the SSO/SAML config UI to tenants is misleading. Mirror the existing pattern from PR #36 used for AI Provider and Storage: loader-level redirect plus tab filter via selfHostedOnly.