### PR TITLE
Consolidate stream finalization and persist tool errors

### DIFF
--- a/app/components/conversation-helpers.test.ts
+++ b/app/components/conversation-helpers.test.ts
@@ -74,6 +74,27 @@ describe("itemsToUIMessages", () => {
     expect(msgs[0].parts[2]).toMatchObject({ type: "text", text: "Here's what I found." });
   });
 
+  it("restores failed tool calls as output-error parts with errorText", () => {
+    const items = [
+      assistantItem("a1", {
+        parts: [
+          { type: "tool-call", toolName: "bash", toolCallId: "tc1", input: { command: "ls" }, output: "command timed out", isError: true },
+          { type: "text", text: "The command failed." },
+        ],
+        text: "The command failed.",
+      }),
+    ];
+    const msgs = itemsToUIMessages(items);
+    expect(msgs[0].parts[0]).toMatchObject({
+      type: "dynamic-tool",
+      toolName: "bash",
+      toolCallId: "tc1",
+      state: "output-error",
+      errorText: "command timed out",
+    });
+    expect(msgs[0].parts[0]).not.toHaveProperty("output");
+  });
+
   it("restores multiple tool groups interleaved with text", () => {
     const items = [
       assistantItem("a1", {

--- a/app/components/conversation-helpers.ts
+++ b/app/components/conversation-helpers.ts
@@ -37,7 +37,7 @@ export function itemsToUIMessages(dbItems: MessageItem[]): UIMessage[] {
       }
     } else if (item.role === "assistant") {
       const content = item.content as {
-        parts?: Array<{ type: string; text?: string; toolName?: string; toolCallId?: string; input?: unknown; output?: string }>;
+        parts?: Array<{ type: string; text?: string; toolName?: string; toolCallId?: string; input?: unknown; output?: string; isError?: boolean }>;
         text?: string;
         toolCalls?: Array<{ id: string; tool: string; input: unknown; result?: string }>;
       } | null;
@@ -55,9 +55,10 @@ export function itemsToUIMessages(dbItems: MessageItem[]): UIMessage[] {
               type: "dynamic-tool",
               toolName: p.toolName,
               toolCallId: p.toolCallId || crypto.randomUUID(),
-              state: "output-available",
               input: p.input,
-              output: p.output || "",
+              ...(p.isError
+                ? { state: "output-error", errorText: p.output || "" }
+                : { state: "output-available", output: p.output || "" }),
             } as UIMessage["parts"][number]);
           }
         }

--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -332,8 +332,8 @@ describe("api.agent action", () => {
     });
   });
 
-  describe("onFinish persistence callback", () => {
-    it("passes onFinish to toUIMessageStream", async () => {
+  describe("onEnd persistence callback", () => {
+    it("passes onEnd to toUIMessageStream", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
         [],
@@ -344,8 +344,8 @@ describe("api.agent action", () => {
 
       const result = mockStreamText.mock.results[0].value;
       const callArgs = result.toUIMessageStream.mock.calls[0][0];
-      expect(callArgs).toHaveProperty("onFinish");
-      expect(typeof callArgs.onFinish).toBe("function");
+      expect(callArgs).toHaveProperty("onEnd");
+      expect(typeof callArgs.onEnd).toBe("function");
     });
 
     it("persists text and tool-call parts from assistant message", async () => {
@@ -359,7 +359,8 @@ describe("api.agent action", () => {
 
       const result = mockStreamText.mock.results[0].value;
       const callArgs = result.toUIMessageStream.mock.calls[0][0];
-      await callArgs.onFinish({
+      await callArgs.onEnd({
+        isAborted: false,
         responseMessage: {
           parts: [
             { type: "text", text: "Here is the file." },
@@ -391,7 +392,8 @@ describe("api.agent action", () => {
 
       const result = mockStreamText.mock.results[0].value;
       const callArgs = result.toUIMessageStream.mock.calls[0][0];
-      await callArgs.onFinish({
+      await callArgs.onEnd({
+        isAborted: false,
         responseMessage: {
           parts: [
             { type: "text", text: "Let me check." },
@@ -424,7 +426,8 @@ describe("api.agent action", () => {
 
       const result = mockStreamText.mock.results[0].value;
       const callArgs = result.toUIMessageStream.mock.calls[0][0];
-      await callArgs.onFinish({
+      await callArgs.onEnd({
+        isAborted: false,
         responseMessage: {
           parts: [
             { type: "text", text: "What color?" },
@@ -453,7 +456,8 @@ describe("api.agent action", () => {
 
       const result = mockStreamText.mock.results[0].value;
       const callArgs = result.toUIMessageStream.mock.calls[0][0];
-      await callArgs.onFinish({
+      await callArgs.onEnd({
+        isAborted: false,
         responseMessage: {
           parts: [
             { type: "text", text: "First." },
@@ -481,13 +485,139 @@ describe("api.agent action", () => {
 
       const result = mockStreamText.mock.results[0].value;
       const callArgs = result.toUIMessageStream.mock.calls[0][0];
-      await callArgs.onFinish({
+      await callArgs.onEnd({
+        isAborted: false,
         responseMessage: { parts: [{ type: "text", text: "Done." }] },
       });
 
       const setCalls = mockDb._updateSet.mock.calls;
       const contentUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "completed");
       expect(contentUpdate).toBeDefined();
+    });
+
+    it("sets status to aborted and persists partial parts when the stream was aborted", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const result = mockStreamText.mock.results[0].value;
+      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: true,
+        responseMessage: {
+          parts: [
+            { type: "text", text: "Partial response" },
+            { type: "dynamic-tool", toolName: "read", toolCallId: "tc-1", state: "output-available", input: { path: "/f" }, output: "data" },
+          ],
+        },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const abortUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "aborted");
+      expect(abortUpdate).toBeDefined();
+      const content = (abortUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      const parts = content.parts as Array<Record<string, unknown>>;
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toMatchObject({ type: "text", text: "Partial response" });
+      expect(parts[1]).toMatchObject({ type: "tool-call", toolName: "read", toolCallId: "tc-1" });
+      const completedUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "completed");
+      expect(completedUpdate).toBeUndefined();
+    });
+
+    it("sets status to error when the stream errored before finishing", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const streamArgs = mockStreamText.mock.calls[0][0];
+      streamArgs.onError({ error: new Error("provider failure") });
+
+      const result = mockStreamText.mock.results[0].value;
+      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: false,
+        responseMessage: { parts: [{ type: "text", text: "Partial before error" }] },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const errorUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "error");
+      expect(errorUpdate).toBeDefined();
+      const content = (errorUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      expect(content.text).toBe("Partial before error");
+      const completedUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "completed");
+      expect(completedUpdate).toBeUndefined();
+    });
+
+    it("persists failed tool calls with isError and their errorText", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const result = mockStreamText.mock.results[0].value;
+      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: false,
+        responseMessage: {
+          parts: [
+            { type: "dynamic-tool", toolName: "bash", toolCallId: "tc-1", state: "output-error", input: { command: "ls" }, errorText: "command timed out" },
+            { type: "text", text: "The command failed." },
+          ],
+        },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const contentUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).content !== undefined);
+      const content = (contentUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      const parts = content.parts as Array<Record<string, unknown>>;
+      expect(parts[0]).toMatchObject({
+        type: "tool-call",
+        toolName: "bash",
+        toolCallId: "tc-1",
+        output: "command timed out",
+        isError: true,
+      });
+    });
+
+    it("skips tool calls that never reached a terminal state", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const result = mockStreamText.mock.results[0].value;
+      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: true,
+        responseMessage: {
+          parts: [
+            { type: "text", text: "Checking" },
+            { type: "dynamic-tool", toolName: "read", toolCallId: "tc-1", state: "input-streaming", input: undefined },
+            { type: "dynamic-tool", toolName: "grep", toolCallId: "tc-2", state: "input-available", input: { pattern: "x" } },
+          ],
+        },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const contentUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).content !== undefined);
+      const content = (contentUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      const parts = content.parts as Array<Record<string, unknown>>;
+      expect(parts).toHaveLength(1);
+      expect(parts[0]).toMatchObject({ type: "text", text: "Checking" });
     });
   });
 
@@ -1083,7 +1213,8 @@ describe("api.agent action", () => {
 
       const result = mockStreamText.mock.results[0].value;
       const callArgs = result.toUIMessageStream.mock.calls[0][0];
-      await callArgs.onFinish({
+      await callArgs.onEnd({
+        isAborted: false,
         responseMessage: { parts: [{ type: "text", text: "Done." }] },
       });
 
@@ -1095,8 +1226,8 @@ describe("api.agent action", () => {
     });
   });
 
-  describe("onAbort callback", () => {
-    it("passes onAbort to streamText", async () => {
+  describe("stream termination callbacks", () => {
+    it("does not pass onAbort to streamText (abort persistence is consolidated in onEnd)", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
         [],
@@ -1106,111 +1237,9 @@ describe("api.agent action", () => {
       await callAction(request);
 
       const streamArgs = mockStreamText.mock.calls[0][0];
-      expect(streamArgs.onAbort).toBeDefined();
-      expect(typeof streamArgs.onAbort).toBe("function");
+      expect(streamArgs.onAbort).toBeUndefined();
     });
 
-    it("updates assistant item with status aborted and partial stats on abort", async () => {
-      mockDb._selectResults = [
-        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
-        [],
-      ];
-      mockDb._selectCallCount = 0;
-      const request = buildRequest(validBody());
-      await callAction(request);
-
-      const streamArgs = mockStreamText.mock.calls[0][0];
-      await streamArgs.onAbort({
-        steps: [
-          {
-            text: "Partial response",
-            toolCalls: [
-              { toolName: "read", toolCallId: "tc-1", args: { path: "/file" } },
-            ],
-            toolResults: [
-              { toolCallId: "tc-1", result: "file content" },
-            ],
-            usage: { inputTokens: 200, outputTokens: 100 },
-          },
-          {
-            text: " continued",
-            toolCalls: [],
-            toolResults: [],
-            usage: { inputTokens: 50, outputTokens: 25 },
-          },
-        ],
-      });
-
-      const setCalls = mockDb._updateSet.mock.calls;
-      const abortUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "aborted");
-      expect(abortUpdate).toBeDefined();
-      const content = (abortUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
-      const parts = content.parts as Array<Record<string, unknown>>;
-      expect(parts).toHaveLength(3);
-      expect(parts[0]).toMatchObject({ type: "text", text: "Partial response" });
-      expect(parts[1]).toMatchObject({ type: "tool-call", toolName: "read", toolCallId: "tc-1" });
-      expect(parts[2]).toMatchObject({ type: "text", text: " continued" });
-      expect(content.text).toBe("Partial response continued");
-      const stats = content.stats as Record<string, number>;
-      expect(stats.tokens).toBe(375);
-      expect(stats.toolUses).toBe(1);
-    });
-
-    it("excludes askUserQuestion tool calls from aborted parts", async () => {
-      mockDb._selectResults = [
-        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
-        [],
-      ];
-      mockDb._selectCallCount = 0;
-      const request = buildRequest(validBody());
-      await callAction(request);
-
-      const streamArgs = mockStreamText.mock.calls[0][0];
-      await streamArgs.onAbort({
-        steps: [
-          {
-            text: "Pick a color",
-            toolCalls: [
-              { toolName: "askUserQuestion", toolCallId: "tc-ask", args: {} },
-              { toolName: "read", toolCallId: "tc-read", args: { path: "/f" } },
-            ],
-            toolResults: [],
-            usage: { inputTokens: 10, outputTokens: 5 },
-          },
-        ],
-      });
-
-      const setCalls = mockDb._updateSet.mock.calls;
-      const abortUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "aborted");
-      const content = (abortUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
-      const parts = content.parts as Array<Record<string, unknown>>;
-      expect(parts.every((p) => p.toolName !== "askUserQuestion")).toBe(true);
-      const stats = content.stats as Record<string, number>;
-      expect(stats.toolUses).toBe(1);
-    });
-
-    it("updates conversation updatedAt on abort", async () => {
-      mockDb._selectResults = [
-        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
-        [],
-      ];
-      mockDb._selectCallCount = 0;
-      const request = buildRequest(validBody());
-      await callAction(request);
-
-      mockDb._updateSet.mockClear();
-      const streamArgs = mockStreamText.mock.calls[0][0];
-      await streamArgs.onAbort({
-        steps: [{ text: "partial", toolCalls: [], toolResults: [], usage: { inputTokens: 5, outputTokens: 5 } }],
-      });
-
-      const setCalls = mockDb._updateSet.mock.calls;
-      const updatedAtUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).updatedAt !== undefined);
-      expect(updatedAtUpdate).toBeDefined();
-    });
-  });
-
-  describe("onError callback", () => {
     it("passes onError to streamText", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
@@ -1225,7 +1254,7 @@ describe("api.agent action", () => {
       expect(typeof streamArgs.onError).toBe("function");
     });
 
-    it("updates assistant item status to error", async () => {
+    it("onError does not write to the DB directly (persistence is consolidated in onEnd)", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
         [],
@@ -1234,14 +1263,11 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
+      mockDb._updateSet.mockClear();
       const streamArgs = mockStreamText.mock.calls[0][0];
       streamArgs.onError({ error: new Error("provider failure") });
 
-      await vi.waitFor(() => {
-        const setCalls = mockDb._updateSet.mock.calls;
-        const errorUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).status === "error");
-        expect(errorUpdate).toBeDefined();
-      });
+      expect(mockDb._updateSet).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -233,6 +233,7 @@ export async function action({ request }: Route.ActionArgs) {
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
   let toolUseCount = 0;
+  let streamErrored = false;
   const startTime = Date.now();
 
   const systemForStream = promptCachingEnabled
@@ -305,74 +306,9 @@ export async function action({ request }: Route.ActionArgs) {
         }
       }
     },
-    onAbort: async ({ steps }) => {
-      try {
-        const durationMs = Date.now() - startTime;
-        let abortInputTokens = 0;
-        let abortOutputTokens = 0;
-        let abortToolUses = 0;
-
-        const parts: Array<
-          | { type: "text"; text: string }
-          | { type: "tool-call"; toolName: string; toolCallId: string; input: unknown; output: string }
-        > = [];
-        for (const step of steps) {
-          if (step.text) {
-            parts.push({ type: "text", text: step.text });
-          }
-          for (const tc of step.toolCalls || []) {
-            if (tc.toolName === "askUserQuestion") continue;
-            abortToolUses++;
-            const matchingResult = step.toolResults?.find(
-              (r) => r.toolCallId === tc.toolCallId
-            );
-            parts.push({
-              type: "tool-call",
-              toolName: tc.toolName,
-              toolCallId: tc.toolCallId,
-              input: tc.input,
-              output: typeof matchingResult?.output === "string"
-                ? matchingResult.output
-                : JSON.stringify(matchingResult?.output || ""),
-            });
-          }
-          if (step.usage) {
-            abortInputTokens += step.usage.inputTokens || 0;
-            abortOutputTokens += step.usage.outputTokens || 0;
-          }
-        }
-
-        const text = parts
-          .filter((p): p is { type: "text"; text: string } => p.type === "text")
-          .map((p) => p.text)
-          .join("");
-        const stats = {
-          toolUses: abortToolUses,
-          tokens: abortInputTokens + abortOutputTokens,
-          durationMs,
-        };
-
-        await db
-          .update(items)
-          .set({ content: { parts, text, stats }, status: "aborted" })
-          .where(eq(items.id, assistantItemId));
-
-        await db
-          .update(conversations)
-          .set({ updatedAt: new Date() })
-          .where(eq(conversations.id, conversationId));
-
-        console.log(`[agent] Stream aborted for conversation=${conversationId} tokens=${stats.tokens} tools=${stats.toolUses} duration=${stats.durationMs}ms`);
-      } catch (err) {
-        console.error(`[agent] Abort cleanup error for conversation=${conversationId}:`, err);
-      }
-    },
     onError: ({ error }) => {
+      streamErrored = true;
       console.error(`[agent] Stream error for conversation=${conversationId}:`, error);
-      db.update(items)
-        .set({ status: "error" })
-        .where(eq(items.id, assistantItemId))
-        .catch((err: unknown) => console.error(`[agent] Error status update failed:`, err));
     },
   });
 
@@ -381,8 +317,9 @@ export async function action({ request }: Route.ActionArgs) {
   const innerUiStream = result.toUIMessageStream({
     originalMessages: uiMessages,
     sendFinish: false,
-    onFinish: async ({ responseMessage: assistantMessage }) => {
+    onEnd: async ({ responseMessage: assistantMessage, isAborted }) => {
       try {
+        const status = isAborted ? "aborted" : streamErrored ? "error" : "completed";
         const durationMs = Date.now() - startTime;
         const stats = {
           toolUses: toolUseCount,
@@ -392,7 +329,7 @@ export async function action({ request }: Route.ActionArgs) {
 
         const parts: Array<
           | { type: "text"; text: string }
-          | { type: "tool-call"; toolName: string; toolCallId: string; input: unknown; output: string }
+          | { type: "tool-call"; toolName: string; toolCallId: string; input: unknown; output: string; isError?: true }
           | { type: "step-start" }
         > = [];
         for (const part of assistantMessage.parts) {
@@ -403,9 +340,21 @@ export async function action({ request }: Route.ActionArgs) {
           } else if (part.type === "step-start") {
             parts.push({ type: "step-start" });
           } else if (part.type === "dynamic-tool" || (part.type as string).startsWith("tool-")) {
-            const tp = part as { toolName?: string; toolCallId?: string; input?: unknown; output?: unknown; type: string };
+            const tp = part as { toolName?: string; toolCallId?: string; input?: unknown; output?: unknown; errorText?: string; state?: string; type: string };
             const name = tp.toolName || tp.type.replace("tool-", "");
             if (name === "askUserQuestion") continue;
+            if (tp.state === "input-streaming" || tp.state === "input-available") continue;
+            if (tp.state === "output-error") {
+              parts.push({
+                type: "tool-call",
+                toolName: name,
+                toolCallId: tp.toolCallId || crypto.randomUUID(),
+                input: tp.input,
+                output: tp.errorText || "",
+                isError: true,
+              });
+              continue;
+            }
             parts.push({
               type: "tool-call",
               toolName: name,
@@ -425,7 +374,7 @@ export async function action({ request }: Route.ActionArgs) {
           .update(items)
           .set({
             content: { parts, text, stats },
-            status: "completed",
+            status,
           })
           .where(eq(items.id, assistantItemId));
 
@@ -434,7 +383,7 @@ export async function action({ request }: Route.ActionArgs) {
           .set({ updatedAt: new Date() })
           .where(eq(conversations.id, conversationId));
 
-        console.log(`[agent] Stream completed for conversation=${conversationId} tokens=${stats.tokens} tools=${stats.toolUses} duration=${stats.durationMs}ms`);
+        console.log(`[agent] Stream ${status} for conversation=${conversationId} tokens=${stats.tokens} tools=${stats.toolUses} duration=${stats.durationMs}ms`);
       } catch (cleanupError) {
         console.error(`[agent] Cleanup error for conversation=${conversationId}:`, cleanupError);
       }


### PR DESCRIPTION
- Persist final status in the single onEnd callback (fires on every termination path), so aborted/errored turns are no longer overwritten as completed
- Drop the separate onAbort/onError DB writes; onError now only flags the error, and partial output survives on error
- Persist failed tool calls with isError + errorText instead of empty successful outputs, and rehydrate them as output-error parts
- Skip tool calls that never reached a terminal state