### PR TITLE
Adopt current AI SDK v7 API names and drop redundant Bedrock compaction fetch

### DIFF
--- a/app/components/agent-conversation.tsx
+++ b/app/components/agent-conversation.tsx
@@ -104,7 +104,7 @@ export function AgentConversation({
     id: conversationId,
     messages: initialUIMessages,
     transport,
-    experimental_throttle: 50,
+    throttle: 50,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     onToolCall({ toolCall }) {
       if (toolCall.toolName === "askUserQuestion") {

--- a/app/lib/models.server.test.ts
+++ b/app/lib/models.server.test.ts
@@ -1,45 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 vi.mock("~/lib/db/index.server", () => ({ db: {} }));
 vi.mock("~/lib/ai-provider.server", () => ({ getAIProviderConfig: vi.fn() }));
 
-const mockSign = vi.fn().mockResolvedValue({
-  method: "POST",
-  url: new URL("https://bedrock.example.com"),
-  headers: new Headers({ authorization: "AWS4-HMAC-SHA256 re-signed", "x-amz-date": "20260222T000000Z" }),
-  body: "",
-});
-
-class MockAwsV4Signer {
-  options: Record<string, unknown>;
-  constructor(options: Record<string, unknown>) {
-    this.options = options;
-    MockAwsV4Signer.instances.push(this);
-  }
-  sign = mockSign;
-  static instances: MockAwsV4Signer[] = [];
-}
-
-vi.mock("aws4fetch", () => ({
-  AwsV4Signer: MockAwsV4Signer,
-}));
-
-import { createBedrockCompactionFetch, getAgentEffort } from "./models.server";
-
-const mockFetch = vi.fn().mockResolvedValue(new Response("ok"));
-
-beforeEach(() => {
-  vi.stubGlobal("fetch", mockFetch);
-  mockFetch.mockClear();
-  mockSign.mockClear();
-  MockAwsV4Signer.instances = [];
-});
-
-const compactionFetch = createBedrockCompactionFetch(
-  "us-east-1",
-  "AKID",
-  "SECRET",
-);
+import { getAgentEffort } from "./models.server";
 
 describe("getAgentEffort", () => {
   it("returns xhigh for claude-opus-4-8 on anthropic", () => {
@@ -64,71 +28,5 @@ describe("getAgentEffort", () => {
   it("returns undefined for bedrock regardless of model", () => {
     expect(getAgentEffort("bedrock", "claude-opus-4-8")).toBeUndefined();
     expect(getAgentEffort("bedrock", "anthropic.claude-opus-4-8")).toBeUndefined();
-  });
-});
-
-describe("createBedrockCompactionFetch", () => {
-  it("injects betas and re-signs when context_management is present", async () => {
-    const body = JSON.stringify({
-      context_management: { enabled: true },
-      messages: [],
-    });
-
-    await compactionFetch("https://bedrock.example.com", {
-      method: "POST",
-      body,
-      headers: { "content-type": "application/json" },
-    });
-
-    const instance = MockAwsV4Signer.instances[0];
-    const signedBody = JSON.parse(instance.options.body as string);
-    expect(signedBody.anthropic_beta).toContain("compact-2026-01-12");
-    expect(signedBody.anthropic_beta).toContain("context-management-2025-06-27");
-    expect(instance.options.region).toBe("us-east-1");
-    expect(instance.options.service).toBe("bedrock");
-    expect(mockSign).toHaveBeenCalledOnce();
-    expect(mockFetch).toHaveBeenCalledOnce();
-  });
-
-  it("preserves existing anthropic_beta entries", async () => {
-    const body = JSON.stringify({
-      context_management: { enabled: true },
-      anthropic_beta: ["existing-beta-1"],
-    });
-
-    await compactionFetch("https://bedrock.example.com", {
-      method: "POST",
-      body,
-    });
-
-    const signedBody = JSON.parse(MockAwsV4Signer.instances[0].options.body as string);
-    expect(signedBody.anthropic_beta).toContain("existing-beta-1");
-    expect(signedBody.anthropic_beta).toContain("compact-2026-01-12");
-    expect(signedBody.anthropic_beta).toContain("context-management-2025-06-27");
-  });
-
-  it("does not modify body or re-sign when context_management is absent", async () => {
-    const body = JSON.stringify({ messages: [{ role: "user", content: "hi" }] });
-
-    await compactionFetch("https://bedrock.example.com", {
-      method: "POST",
-      body,
-    });
-
-    expect(MockAwsV4Signer.instances).toHaveLength(0);
-    expect(mockFetch.mock.calls[0][1].body).toBe(body);
-  });
-
-  it("handles non-string body without throwing", async () => {
-    const formData = new FormData();
-
-    await compactionFetch("https://bedrock.example.com", {
-      method: "POST",
-      body: formData as never,
-    });
-
-    expect(MockAwsV4Signer.instances).toHaveLength(0);
-    expect(mockFetch).toHaveBeenCalledOnce();
-    expect(mockFetch.mock.calls[0][1].body).toBe(formData);
   });
 });

--- a/app/lib/models.server.ts
+++ b/app/lib/models.server.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { createAnthropic } from "@ai-sdk/anthropic";
-import { createBedrockAnthropic } from "@ai-sdk/amazon-bedrock/anthropic";
+import { createAmazonBedrockAnthropic } from "@ai-sdk/amazon-bedrock/anthropic";
 import type { LanguageModel } from "ai";
 import { getAIProviderConfig, type AIProvider } from "./ai-provider.server";
 import { db } from "./db/index.server";
@@ -400,55 +400,6 @@ export async function getToolConfig(organizationId: string): Promise<string[]> {
   return [...baseTools, ...mapped];
 }
 
-export function createBedrockCompactionFetch(
-  region: string,
-  accessKeyId: string,
-  secretAccessKey: string,
-) {
-  const signingKeyCache = new Map<string, ArrayBuffer>();
-  return async (
-    url: RequestInfo | URL,
-    options?: RequestInit,
-  ): Promise<Response> => {
-    if (options?.body && typeof options.body === "string") {
-      const body = JSON.parse(options.body);
-      if (body.context_management) {
-        const betas = new Set<string>(body.anthropic_beta || []);
-        betas.add("compact-2026-01-12");
-        betas.add("context-management-2025-06-27");
-        body.anthropic_beta = Array.from(betas);
-        const newBody = JSON.stringify(body);
-
-        const { AwsV4Signer } = await import("aws4fetch");
-        const urlStr =
-          typeof url === "string"
-            ? url
-            : url instanceof URL
-              ? url.href
-              : (url as Request).url;
-        const signer = new AwsV4Signer({
-          url: urlStr,
-          method: "POST",
-          headers: (options.headers ?? {}) as HeadersInit,
-          body: newBody,
-          region,
-          accessKeyId,
-          secretAccessKey,
-          service: "bedrock",
-          cache: signingKeyCache,
-        });
-        const signed = await signer.sign();
-        return fetch(url, {
-          ...options,
-          body: newBody,
-          headers: signed.headers,
-        });
-      }
-    }
-    return fetch(url, options);
-  };
-}
-
 const XHIGH_EFFORT_MODELS = ["claude-opus-4-7", "claude-opus-4-8"];
 
 export function getAgentEffort(
@@ -470,15 +421,10 @@ export async function getModel(
   const modelId = await getEffectiveModel(memberId, organizationId);
 
   if (config?.provider === "bedrock" && config.awsRegion && config.awsAccessKeyId && config.awsSecretAccessKey) {
-    const bedrock = createBedrockAnthropic({
+    const bedrock = createAmazonBedrockAnthropic({
       region: config.awsRegion,
       accessKeyId: config.awsAccessKeyId,
       secretAccessKey: config.awsSecretAccessKey,
-      fetch: createBedrockCompactionFetch(
-        config.awsRegion,
-        config.awsAccessKeyId,
-        config.awsSecretAccessKey,
-      ),
     });
     return { model: bedrock(modelId), modelId };
   }
@@ -495,7 +441,7 @@ export async function getTitleGenerationModel(
   const config = await getAIProviderConfig(organizationId);
 
   if (config?.provider === "bedrock" && config.awsRegion && config.awsAccessKeyId && config.awsSecretAccessKey) {
-    const bedrock = createBedrockAnthropic({
+    const bedrock = createAmazonBedrockAnthropic({
       region: config.awsRegion,
       accessKeyId: config.awsAccessKeyId,
       secretAccessKey: config.awsSecretAccessKey,

--- a/app/lib/title-generation.server.ts
+++ b/app/lib/title-generation.server.ts
@@ -23,7 +23,7 @@ export async function generateAndSaveTitle(
   const model = await getTitleGenerationModel(organizationId);
   const { text } = await generateText({
     model,
-    system: TITLE_PROMPT,
+    instructions: TITLE_PROMPT,
     prompt: `Title this message:\n\n${trimmed.slice(0, 2000)}`,
     maxOutputTokens: 50,
   });

--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -24,11 +24,13 @@ const mockCreateUIMessageStreamResponse = vi.fn().mockImplementation(() =>
   new Response("data: test\n\n", { headers: { "Content-Type": "text/event-stream" } })
 );
 const mockCreateUIMessageStream = vi.fn();
+const mockToUIMessageStream = vi.fn();
 vi.mock("ai", () => ({
   streamText: (...args: unknown[]) => mockStreamText(...args),
   convertToModelMessages: (...args: unknown[]) => mockConvertToModelMessages(...args),
-  stepCountIs: (n: number) => ({ type: "stepCount", value: n }),
+  isStepCount: (n: number) => ({ type: "stepCount", value: n }),
   smoothStream: () => "mock-smooth-stream",
+  toUIMessageStream: (...args: unknown[]) => mockToUIMessageStream(...args),
   createUIMessageStream: (...args: unknown[]) => mockCreateUIMessageStream(...args),
   createUIMessageStreamResponse: (...args: unknown[]) => mockCreateUIMessageStreamResponse(...args),
 }));
@@ -69,9 +71,10 @@ function validBody() {
 
 function setupMockStreamText() {
   mockStreamText.mockReturnValue({
-    toUIMessageStream: vi.fn().mockReturnValue(new ReadableStream()),
+    stream: "mock-full-stream",
     consumeStream: vi.fn().mockResolvedValue(undefined),
   });
+  mockToUIMessageStream.mockReturnValue(new ReadableStream());
   mockCreateUIMessageStream.mockImplementation((opts: { execute?: (args: { writer: { merge: (s: unknown) => void; write: (c: unknown) => void } }) => Promise<void> | void }) => {
     const writer = { merge: vi.fn(), write: vi.fn() };
     void Promise.resolve(opts.execute?.({ writer }));
@@ -275,13 +278,13 @@ describe("api.agent action", () => {
       expect(mockStreamText).toHaveBeenCalledWith(
         expect.objectContaining({
           model: "mock-model",
-          system: "test system prompt",
+          instructions: "test system prompt",
           tools: {},
         })
       );
     });
 
-    it("calls toUIMessageStream on the result", async () => {
+    it("converts the result stream to a UI message stream", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
         [],
@@ -291,8 +294,9 @@ describe("api.agent action", () => {
       const response = await callAction(request);
 
       expect(response).toBeInstanceOf(Response);
-      const result = mockStreamText.mock.results[0].value;
-      expect(result.toUIMessageStream).toHaveBeenCalled();
+      expect(mockToUIMessageStream).toHaveBeenCalledWith(
+        expect.objectContaining({ stream: "mock-full-stream", tools: {} })
+      );
     });
 
     it("calls consumeStream for guaranteed persistence", async () => {
@@ -342,8 +346,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       expect(callArgs).toHaveProperty("onEnd");
       expect(typeof callArgs.onEnd).toBe("function");
     });
@@ -357,8 +360,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: {
@@ -390,8 +392,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: {
@@ -424,8 +425,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: {
@@ -454,8 +454,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: {
@@ -483,8 +482,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: { parts: [{ type: "text", text: "Done." }] },
@@ -504,8 +502,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: true,
         responseMessage: {
@@ -540,8 +537,7 @@ describe("api.agent action", () => {
       const streamArgs = mockStreamText.mock.calls[0][0];
       streamArgs.onError({ error: new Error("provider failure") });
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: { parts: [{ type: "text", text: "Partial before error" }] },
@@ -565,8 +561,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: {
@@ -599,8 +594,7 @@ describe("api.agent action", () => {
       const request = buildRequest(validBody());
       await callAction(request);
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: true,
         responseMessage: {
@@ -1190,7 +1184,7 @@ describe("api.agent action", () => {
     });
   });
 
-  describe("onStepFinish token tracking", () => {
+  describe("onStepEnd token tracking", () => {
     it("does not count askUserQuestion toward toolUseCount", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
@@ -1202,7 +1196,7 @@ describe("api.agent action", () => {
 
       const streamArgs = mockStreamText.mock.calls[0][0];
       let toolCount = 0;
-      streamArgs.onStepFinish({
+      streamArgs.onStepEnd({
         usage: { inputTokens: 100, outputTokens: 50 },
         toolCalls: [
           { toolName: "read" },
@@ -1211,8 +1205,7 @@ describe("api.agent action", () => {
         ],
       });
 
-      const result = mockStreamText.mock.results[0].value;
-      const callArgs = result.toUIMessageStream.mock.calls[0][0];
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
       await callArgs.onEnd({
         isAborted: false,
         responseMessage: { parts: [{ type: "text", text: "Done." }] },

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/api.agent";
-import { streamText, convertToModelMessages, stepCountIs, smoothStream, createUIMessageStream, createUIMessageStreamResponse, type UIMessage } from "ai";
+import { streamText, convertToModelMessages, isStepCount, smoothStream, toUIMessageStream, createUIMessageStream, createUIMessageStreamResponse, type UIMessage } from "ai";
 import { getAgentConfig } from "~/lib/agent.server";
 import { requireActiveAuth } from "~/lib/auth.server";
 import { db } from "~/lib/db/index.server";
@@ -236,7 +236,7 @@ export async function action({ request }: Route.ActionArgs) {
   let streamErrored = false;
   const startTime = Date.now();
 
-  const systemForStream = promptCachingEnabled
+  const instructionsForStream = promptCachingEnabled
     ? {
         role: "system" as const,
         content: systemPrompt,
@@ -248,7 +248,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const result = streamText({
     model,
-    system: systemForStream,
+    instructions: instructionsForStream,
     messages: modelMessages,
     tools,
     prepareStep: promptCachingEnabled
@@ -291,9 +291,9 @@ export async function action({ request }: Route.ActionArgs) {
       },
     },
     experimental_transform: smoothStream(),
-    stopWhen: stepCountIs(50),
+    stopWhen: isStepCount(50),
     abortSignal: request.signal,
-    onStepFinish: ({ usage, toolCalls }) => {
+    onStepEnd: ({ usage, toolCalls }) => {
       if (usage) {
         totalInputTokens += usage.inputTokens || 0;
         totalOutputTokens += usage.outputTokens || 0;
@@ -314,7 +314,9 @@ export async function action({ request }: Route.ActionArgs) {
 
   const compactionBlockIds = new Set<string>();
 
-  const innerUiStream = result.toUIMessageStream({
+  const innerUiStream = toUIMessageStream({
+    stream: result.stream,
+    tools,
     originalMessages: uiMessages,
     sendFinish: false,
     onEnd: async ({ responseMessage: assistantMessage, isAborted }) => {
@@ -424,7 +426,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const uiStream = createUIMessageStream({
     originalMessages: uiMessages,
-    onFinish: stopHeartbeat,
+    onEnd: stopHeartbeat,
     execute: ({ writer }) => {
       if (!isSaas()) {
         heartbeat = setInterval(() => {


### PR DESCRIPTION
- Rename deprecated v6 aliases to their v7 names: stepCountIs→isStepCount, system→instructions, onStepFinish→onStepEnd, onFinish→onEnd (UI stream), experimental_throttle→throttle, createBedrockAnthropic→createAmazonBedrockAnthropic
- Replace deprecated result.toUIMessageStream() with the stateless toUIMessageStream({ stream, tools, ... })
- Delete createBedrockCompactionFetch: the provider now auto-adds the compaction/context-management betas and threads them into the Bedrock request body, so the custom re-signing fetch was a no-op
- Verified: typecheck clean, 208/208 tests, production build passes