### PR TITLE
Type chat messages end-to-end with UIMessage generics

### DIFF
--- a/app/components/agent-conversation.tsx
+++ b/app/components/agent-conversation.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useRef, useEffect, useMemo, memo } from "react";
 import { useRevalidator, useBlocker, Link } from "react-router";
-import { useChat, type UIMessage } from "@ai-sdk/react";
+import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import type { CompilerUIMessage } from "~/lib/chat-message";
 import { useStickToBottom } from "use-stick-to-bottom";
 import { Streamdown } from "streamdown";
 import type { Item } from "~/lib/types";
@@ -76,7 +77,7 @@ export function AgentConversation({
 
   const initialUIMessages = useMemo(() => itemsToUIMessages(initialItems), []);
 
-  const transport = useMemo(() => new DefaultChatTransport({
+  const transport = useMemo(() => new DefaultChatTransport<CompilerUIMessage>({
     api: "/api/agent",
     body: { conversationId },
     prepareSendMessagesRequest({ messages: msgs, body: extraBody }) {
@@ -100,17 +101,17 @@ export function AgentConversation({
     stop,
     addToolOutput,
     setMessages,
-  } = useChat({
+  } = useChat<CompilerUIMessage>({
     id: conversationId,
     messages: initialUIMessages,
     transport,
     throttle: 50,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     onToolCall({ toolCall }) {
+      if (toolCall.dynamic) return;
       if (toolCall.toolName === "askUserQuestion") {
-        const toolInput = toolCall.input as { questions: PendingQuestionData[] };
         setPendingQuestion({
-          questions: toolInput.questions,
+          questions: toolCall.input.questions,
           toolCallId: toolCall.toolCallId,
         });
       }
@@ -496,9 +497,9 @@ export function AgentConversation({
                       setStreamStartTime(Date.now());
 
                       await addToolOutput({
-                        tool: "askUserQuestion" as never,
+                        tool: "askUserQuestion",
                         toolCallId,
-                        output: JSON.stringify(answersPayload) as never,
+                        output: JSON.stringify(answersPayload),
                       });
                     }}
                     onSkipped={async () => {
@@ -512,9 +513,9 @@ export function AgentConversation({
                       setStreamStartTime(Date.now());
 
                       await addToolOutput({
-                        tool: "askUserQuestion" as never,
+                        tool: "askUserQuestion",
                         toolCallId,
-                        output: JSON.stringify(emptyAnswers) as never,
+                        output: JSON.stringify(emptyAnswers),
                       });
                     }}
                   />
@@ -553,7 +554,7 @@ export function AgentConversation({
   );
 }
 
-const UserMessageRow = memo(function UserMessageRow({ message, itemBlobs }: { message: UIMessage; itemBlobs?: BlobMeta[] }) {
+const UserMessageRow = memo(function UserMessageRow({ message, itemBlobs }: { message: CompilerUIMessage; itemBlobs?: BlobMeta[] }) {
   const [copied, setCopied] = useState(false);
   const contentText = message.parts
     .filter((p): p is { type: "text"; text: string } => p.type === "text")
@@ -642,7 +643,7 @@ const UserMessageRow = memo(function UserMessageRow({ message, itemBlobs }: { me
 });
 
 interface AssistantMessageRowProps {
-  message: UIMessage;
+  message: CompilerUIMessage;
   isStreaming: boolean;
   streamStartTime?: number;
 }

--- a/app/components/conversation-helpers.test.ts
+++ b/app/components/conversation-helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { itemsToUIMessages, buildDisplayItems, buildSegments } from "./conversation-helpers";
 import type { Item } from "~/lib/types";
-import type { UIMessage } from "@ai-sdk/react";
+import type { CompilerUIMessage } from "~/lib/chat-message";
 
 function userItem(id: string, content: string | object): Item {
   return { id, type: "message", role: "user", content, createdAt: Date.now() };
@@ -23,7 +23,7 @@ function toolPart(toolName: string, state: string, output?: string, input?: unkn
     state,
     input: input ?? {},
     output: output ?? "",
-  } as UIMessage["parts"][number];
+  } as CompilerUIMessage["parts"][number];
 }
 
 describe("itemsToUIMessages", () => {
@@ -205,7 +205,7 @@ describe("itemsToUIMessages", () => {
 
 describe("buildDisplayItems", () => {
   it("maps user and assistant messages", () => {
-    const messages: UIMessage[] = [
+    const messages: CompilerUIMessage[] = [
       { id: "u1", role: "user", parts: [textPart("Hi")] },
       { id: "a1", role: "assistant", parts: [textPart("Hello")] },
     ];
@@ -216,7 +216,7 @@ describe("buildDisplayItems", () => {
   });
 
   it("appends system items", () => {
-    const messages: UIMessage[] = [
+    const messages: CompilerUIMessage[] = [
       { id: "u1", role: "user", parts: [textPart("Hi")] },
     ];
     const systemItems: Item[] = [
@@ -235,7 +235,7 @@ describe("buildDisplayItems", () => {
 describe("buildSegments", () => {
   it("groups consecutive text parts", () => {
     const parts = [textPart("First"), textPart("Second")];
-    const segments = buildSegments(parts as UIMessage["parts"]);
+    const segments = buildSegments(parts as CompilerUIMessage["parts"]);
     expect(segments).toHaveLength(1);
     expect(segments[0]).toMatchObject({ kind: "text", text: "First\n\nSecond" });
   });
@@ -245,7 +245,7 @@ describe("buildSegments", () => {
       toolPart("read", "output-available", "done"),
       toolPart("glob", "output-available", "found"),
     ];
-    const segments = buildSegments(parts as UIMessage["parts"]);
+    const segments = buildSegments(parts as CompilerUIMessage["parts"]);
     expect(segments).toHaveLength(1);
     expect(segments[0].kind).toBe("tools");
     if (segments[0].kind === "tools") {
@@ -259,7 +259,7 @@ describe("buildSegments", () => {
       toolPart("read", "output-available"),
       textPart("After tools"),
     ];
-    const segments = buildSegments(parts as UIMessage["parts"]);
+    const segments = buildSegments(parts as CompilerUIMessage["parts"]);
     expect(segments.map((s) => s.kind)).toEqual(["text", "tools", "text"]);
   });
 
@@ -274,7 +274,7 @@ describe("buildSegments", () => {
         ),
         textPart("Great choice!"),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments.map((s) => s.kind)).toEqual(["text", "qa", "text"]);
       expect(segments[1]).toMatchObject({
         kind: "qa",
@@ -290,7 +290,7 @@ describe("buildSegments", () => {
           JSON.stringify({ Color: "Red", Size: "Large" })
         ),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments).toHaveLength(1);
       expect(segments[0]).toMatchObject({
         kind: "qa",
@@ -304,7 +304,7 @@ describe("buildSegments", () => {
         toolPart("askUserQuestion", "input-available"),
         textPart("After"),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments).toHaveLength(1);
       expect(segments[0]).toMatchObject({ kind: "text", text: "Before\n\nAfter" });
     });
@@ -313,7 +313,7 @@ describe("buildSegments", () => {
       const parts = [
         toolPart("askUserQuestion", "input-streaming"),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments).toHaveLength(0);
     });
 
@@ -321,7 +321,7 @@ describe("buildSegments", () => {
       const parts = [
         toolPart("askUserQuestion", "output-available", ""),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments).toHaveLength(0);
     });
 
@@ -329,7 +329,7 @@ describe("buildSegments", () => {
       const parts = [
         toolPart("askUserQuestion", "output-available", "not-json"),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments).toHaveLength(0);
     });
 
@@ -341,7 +341,7 @@ describe("buildSegments", () => {
           JSON.stringify({ Color: "Red", Skipped: "" })
         ),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments).toHaveLength(1);
       expect(segments[0]).toMatchObject({
         kind: "qa",
@@ -357,7 +357,7 @@ describe("buildSegments", () => {
           JSON.stringify({ A: "", B: "" })
         ),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments).toHaveLength(0);
     });
 
@@ -367,7 +367,7 @@ describe("buildSegments", () => {
         toolPart("askUserQuestion", "output-available", JSON.stringify({ Q: "A" })),
         toolPart("glob", "output-available", "files"),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments.map((s) => s.kind)).toEqual(["tools", "qa", "tools"]);
     });
 
@@ -383,7 +383,7 @@ describe("buildSegments", () => {
         textPart("Thanks, continuing with Option A."),
         toolPart("bash", "output-available", "ok"),
       ];
-      const segments = buildSegments(parts as UIMessage["parts"]);
+      const segments = buildSegments(parts as CompilerUIMessage["parts"]);
       expect(segments.map((s) => s.kind)).toEqual(["text", "tools", "qa", "text", "tools"]);
       expect(segments[2]).toMatchObject({
         kind: "qa",

--- a/app/components/conversation-helpers.ts
+++ b/app/components/conversation-helpers.ts
@@ -1,4 +1,4 @@
-import type { UIMessage } from "@ai-sdk/react";
+import type { CompilerUIMessage } from "~/lib/chat-message";
 import type { Item } from "~/lib/types";
 
 export interface MessageItem {
@@ -8,17 +8,17 @@ export interface MessageItem {
 }
 
 export type DisplayItem =
-  | { kind: "user"; message: UIMessage; createdAt: number }
-  | { kind: "assistant"; message: UIMessage; createdAt: number }
+  | { kind: "user"; message: CompilerUIMessage; createdAt: number }
+  | { kind: "assistant"; message: CompilerUIMessage; createdAt: number }
   | { kind: "system"; item: Item; createdAt: number };
 
 export type Segment =
   | { kind: "text"; text: string }
-  | { kind: "tools"; tools: Array<UIMessage["parts"][number]> }
+  | { kind: "tools"; tools: Array<CompilerUIMessage["parts"][number]> }
   | { kind: "qa"; text: string };
 
-export function itemsToUIMessages(dbItems: MessageItem[]): UIMessage[] {
-  const messages: UIMessage[] = [];
+export function itemsToUIMessages(dbItems: MessageItem[]): CompilerUIMessage[] {
+  const messages: CompilerUIMessage[] = [];
 
   for (const item of dbItems) {
     if ("type" in item && (item as Item).type !== "message") continue;
@@ -42,12 +42,12 @@ export function itemsToUIMessages(dbItems: MessageItem[]): UIMessage[] {
         toolCalls?: Array<{ id: string; tool: string; input: unknown; result?: string }>;
       } | null;
 
-      const uiParts: UIMessage["parts"] = [];
+      const uiParts: CompilerUIMessage["parts"] = [];
 
       if (content?.parts) {
         for (const p of content.parts) {
           if (p.type === "step-start") {
-            uiParts.push({ type: "step-start" } as UIMessage["parts"][number]);
+            uiParts.push({ type: "step-start" } as CompilerUIMessage["parts"][number]);
           } else if (p.type === "text" && p.text) {
             uiParts.push({ type: "text", text: p.text });
           } else if (p.type === "tool-call" && p.toolName && p.toolName !== "step-start") {
@@ -59,7 +59,7 @@ export function itemsToUIMessages(dbItems: MessageItem[]): UIMessage[] {
               ...(p.isError
                 ? { state: "output-error", errorText: p.output || "" }
                 : { state: "output-available", output: p.output || "" }),
-            } as UIMessage["parts"][number]);
+            } as CompilerUIMessage["parts"][number]);
           }
         }
       } else {
@@ -75,7 +75,7 @@ export function itemsToUIMessages(dbItems: MessageItem[]): UIMessage[] {
               state: "output-available",
               input: tc.input,
               output: tc.result || "",
-            } as UIMessage["parts"][number]);
+            } as CompilerUIMessage["parts"][number]);
           }
         }
       }
@@ -93,7 +93,7 @@ export function itemsToUIMessages(dbItems: MessageItem[]): UIMessage[] {
   return messages;
 }
 
-export function buildDisplayItems(messages: UIMessage[], systemItems: Item[]): DisplayItem[] {
+export function buildDisplayItems(messages: CompilerUIMessage[], systemItems: Item[]): DisplayItem[] {
   const items: DisplayItem[] = [];
 
   for (const msg of messages) {
@@ -113,7 +113,7 @@ export function buildDisplayItems(messages: UIMessage[], systemItems: Item[]): D
   return items;
 }
 
-export function buildSegments(parts: UIMessage["parts"]): Segment[] {
+export function buildSegments(parts: CompilerUIMessage["parts"]): Segment[] {
   const segments: Segment[] = [];
   for (const part of parts) {
     if (part.type === "text") {

--- a/app/lib/chat-message.ts
+++ b/app/lib/chat-message.ts
@@ -1,0 +1,11 @@
+import type { InferUITools, UIMessage } from "ai";
+import type { AgentToolSet } from "~/lib/tools/index.server";
+
+export type CompilerDataParts = {
+  title: { title: string };
+  heartbeat: null;
+};
+
+export type CompilerTools = InferUITools<AgentToolSet>;
+
+export type CompilerUIMessage = UIMessage<unknown, CompilerDataParts, CompilerTools>;

--- a/app/lib/e2b/sandbox-tools.server.ts
+++ b/app/lib/e2b/sandbox-tools.server.ts
@@ -5,7 +5,7 @@ import { bashDescription, bashParameters, MAX_OUTPUT_CHARS, DEFAULT_TIMEOUT } fr
 import { readDescription, readParameters, MAX_OUTPUT_BYTES, MAX_LINE_CHARS, DEFAULT_LIMIT } from "../tools/read.server";
 import { grepDescription, grepParameters } from "../tools/grep.server";
 import { globDescription, globParameters } from "../tools/glob.server";
-import { askUserQuestionDescription, askUserQuestionParameters } from "../tools/ask-user-question.server";
+import { askUserQuestionDescription, askUserQuestionParameters, askUserQuestionOutputSchema } from "../tools/ask-user-question.server";
 import { repoSyncDescription, repoSyncParameters, executeRepoSync } from "../tools/repo-sync.server";
 import { truncateForModel, GREP_MAX_CHARS, GLOB_MAX_CHARS } from "../tools/index.server";
 
@@ -203,6 +203,7 @@ export function buildSandboxTools(options: BuildSandboxToolsOptions) {
     askUserQuestion: tool({
       description: askUserQuestionDescription,
       inputSchema: askUserQuestionParameters,
+      outputSchema: askUserQuestionOutputSchema,
     }),
   };
 

--- a/app/lib/tools/ask-user-question.server.ts
+++ b/app/lib/tools/ask-user-question.server.ts
@@ -9,6 +9,8 @@ export interface PendingQuestionData {
 
 export const askUserQuestionDescription = "Ask the user a clarifying question with predefined options. Use when you need the user to choose between alternatives or clarify their intent. Provide clear, concise options.";
 
+export const askUserQuestionOutputSchema = z.string();
+
 export const askUserQuestionParameters = z.object({
   questions: z.array(
     z.object({

--- a/app/lib/tools/index.server.ts
+++ b/app/lib/tools/index.server.ts
@@ -4,7 +4,7 @@ import { grepDescription, grepParameters, executeGrep } from "./grep.server";
 import { globDescription, globParameters, executeGlob } from "./glob.server";
 import { readDescription, readParameters, executeRead } from "./read.server";
 import { bashDescription, bashParameters, executeBash } from "./bash.server";
-import { askUserQuestionDescription, askUserQuestionParameters } from "./ask-user-question.server";
+import { askUserQuestionDescription, askUserQuestionParameters, askUserQuestionOutputSchema } from "./ask-user-question.server";
 import { repoSyncDescription, repoSyncParameters, executeRepoSync } from "./repo-sync.server";
 
 export const GREP_MAX_CHARS = 5000;
@@ -57,12 +57,12 @@ interface BuildToolsOptions {
 
 type AnyTool = Tool<any, any>;
 
-export function buildTools(options: BuildToolsOptions) {
-  const { cwd, allowedDirs, signal, enabledTools, organizationId, projectId } = options;
+function agentToolSet(options: BuildToolsOptions) {
+  const { cwd, allowedDirs, signal, organizationId, projectId } = options;
   const toolOptions = { cwd, allowedDirs, signal };
   const repoSyncOptions = { organizationId, projectId, signal };
 
-  const allTools: Record<string, AnyTool> = {
+  return {
     grep: tool({
       description: grepDescription,
       inputSchema: grepParameters,
@@ -88,21 +88,29 @@ export function buildTools(options: BuildToolsOptions) {
     askUserQuestion: tool({
       description: askUserQuestionDescription,
       inputSchema: askUserQuestionParameters,
+      outputSchema: askUserQuestionOutputSchema,
+    }),
+    repoSync: tool({
+      description: repoSyncDescription,
+      inputSchema: repoSyncParameters,
+      execute: async (args) => executeRepoSync(args, repoSyncOptions),
     }),
   };
+}
+
+export type AgentToolSet = ReturnType<typeof agentToolSet>;
+
+export function buildTools(options: BuildToolsOptions) {
+  const allTools = agentToolSet(options);
 
   const filtered: Record<string, AnyTool> = {};
-  for (const name of enabledTools) {
-    if (allTools[name]) {
-      filtered[name] = allTools[name];
+  for (const name of options.enabledTools) {
+    if (name !== "repoSync" && name in allTools) {
+      filtered[name] = allTools[name as keyof AgentToolSet];
     }
   }
 
-  filtered.repoSync = tool({
-    description: repoSyncDescription,
-    inputSchema: repoSyncParameters,
-    execute: async (args) => executeRepoSync(args, repoSyncOptions),
-  });
+  filtered.repoSync = allTools.repoSync;
 
   return filtered;
 }

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -1,5 +1,6 @@
 import type { Route } from "./+types/api.agent";
-import { streamText, convertToModelMessages, isStepCount, smoothStream, toUIMessageStream, createUIMessageStream, createUIMessageStreamResponse, type UIMessage } from "ai";
+import { streamText, convertToModelMessages, isStepCount, smoothStream, toUIMessageStream, createUIMessageStream, createUIMessageStreamResponse } from "ai";
+import type { CompilerUIMessage } from "~/lib/chat-message";
 import { getAgentConfig } from "~/lib/agent.server";
 import { requireActiveAuth } from "~/lib/auth.server";
 import { db } from "~/lib/db/index.server";
@@ -24,7 +25,7 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   const body = await request.json();
-  const message: UIMessage | undefined = body.message;
+  const message: CompilerUIMessage | undefined = body.message;
   const conversationId: string | undefined = body.conversationId;
   const blobIds: string[] | undefined = body.blobIds;
   const projectId: string | undefined = body.projectId;
@@ -185,20 +186,20 @@ export async function action({ request }: Route.ActionArgs) {
 
     const lastMsg = uiMessages[uiMessages.length - 1];
     if (lastMsg && lastMsg.role === "user") {
-      const imageParts: UIMessage["parts"] = [];
+      const imageParts: CompilerUIMessage["parts"] = [];
       for (const img of agentImages) {
         if (SUPPORTED_IMAGE_TYPES.has(img.mediaType)) {
           imageParts.push({
             type: "file",
             mediaType: img.mediaType,
             url: `data:${img.mediaType};base64,${img.base64}`,
-          } as UIMessage["parts"][number]);
+          } as CompilerUIMessage["parts"][number]);
         } else if (img.mediaType === "application/pdf") {
           imageParts.push({
             type: "file",
             mediaType: img.mediaType,
             url: `data:${img.mediaType};base64,${img.base64}`,
-          } as UIMessage["parts"][number]);
+          } as CompilerUIMessage["parts"][number]);
         } else if (img.mediaType.startsWith("text/") || TEXT_MEDIA_TYPES.has(img.mediaType)) {
           const text = Buffer.from(img.base64, "base64").toString("utf-8");
           imageParts.push({ type: "text", text: `[File: ${img.filename || "file"}]\n${text}` });
@@ -424,7 +425,7 @@ export async function action({ request }: Route.ActionArgs) {
     heartbeat = undefined;
   };
 
-  const uiStream = createUIMessageStream({
+  const uiStream = createUIMessageStream<CompilerUIMessage>({
     originalMessages: uiMessages,
     onEnd: stopHeartbeat,
     execute: ({ writer }) => {


### PR DESCRIPTION
- Add CompilerUIMessage = UIMessage<unknown, data parts, InferUITools<AgentToolSet>> shared between server and client (type-only import of the server tool set)
- Restructure buildTools around a typed agentToolSet factory; give askUserQuestion an outputSchema so its output is typed
- useChat/transport/streams/helpers now use the typed message: addToolOutput and onToolCall lose their as-never/manual casts, onData and data-part writes are checked
- Verified: typecheck clean, 208/208 tests, production build passes