### PR TITLE
Make pending questions survive reload via the tool round-trip

### DIFF
--- a/app/components/agent-conversation.tsx
+++ b/app/components/agent-conversation.tsx
@@ -9,7 +9,7 @@ import type { Item } from "~/lib/types";
 import type { PendingQuestionData } from "~/lib/agent.server";
 import { PromptInput, type PendingFile } from "./prompt-input";
 import { NavigationBlocker } from "./navigation-blocker";
-import { itemsToUIMessages, buildDisplayItems, buildSegments } from "./conversation-helpers";
+import { itemsToUIMessages, buildDisplayItems, buildSegments, derivePendingQuestion, type PendingQuestionState } from "./conversation-helpers";
 
 interface AnsweredQuestion {
   question: string;
@@ -32,7 +32,6 @@ interface AgentConversationProps {
   ownsConversation?: boolean;
   onFork?: () => void;
   source?: { id: string; title: string; shareToken: string | null } | null;
-  initialPendingQuestion?: PendingQuestionData[] | null;
   initialBlobsByItemId?: Record<string, BlobMeta[]>;
   initialBlobIds?: string;
   hasStorageConfig?: boolean;
@@ -48,7 +47,6 @@ export function AgentConversation({
   ownsConversation = false,
   onFork,
   source,
-  initialPendingQuestion,
   initialBlobsByItemId,
   initialBlobIds,
   hasStorageConfig = false,
@@ -60,11 +58,9 @@ export function AgentConversation({
   const [networkError, setNetworkError] = useState(false);
   const savedPromptRef = useRef("");
   const savedFilesRef = useRef<PendingFile[]>([]);
-  const [pendingQuestion, setPendingQuestion] = useState<{
-    questions: PendingQuestionData[];
-    toolCallId: string;
-  } | null>(
-    initialPendingQuestion ? { questions: initialPendingQuestion, toolCallId: "" } : null
+  const initialUIMessages = useMemo(() => itemsToUIMessages(initialItems), []);
+  const [pendingQuestion, setPendingQuestion] = useState<PendingQuestionState | null>(
+    () => (readOnly ? null : derivePendingQuestion(initialUIMessages))
   );
   const [systemItems, setSystemItems] = useState<Item[]>(
     initialItems.filter((i) => i.type === "system")
@@ -74,8 +70,6 @@ export function AgentConversation({
   const hasProcessedInitialPrompt = useRef(false);
   const revalidator = useRevalidator();
   const pendingBlobIdsRef = useRef<string[]>([]);
-
-  const initialUIMessages = useMemo(() => itemsToUIMessages(initialItems), []);
 
   const transport = useMemo(() => new DefaultChatTransport<CompilerUIMessage>({
     api: "/api/agent",

--- a/app/components/conversation-helpers.test.ts
+++ b/app/components/conversation-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { itemsToUIMessages, buildDisplayItems, buildSegments } from "./conversation-helpers";
+import { itemsToUIMessages, buildDisplayItems, buildSegments, derivePendingQuestion } from "./conversation-helpers";
 import type { Item } from "~/lib/types";
 import type { CompilerUIMessage } from "~/lib/chat-message";
 
@@ -93,6 +93,26 @@ describe("itemsToUIMessages", () => {
       errorText: "command timed out",
     });
     expect(msgs[0].parts[0]).not.toHaveProperty("output");
+  });
+
+  it("restores pending tool calls as input-available parts", () => {
+    const items = [
+      assistantItem("a1", {
+        parts: [
+          { type: "text", text: "Which option?" },
+          { type: "tool-call", toolName: "askUserQuestion", toolCallId: "tc1", input: { questions: [] }, output: "", pending: true },
+        ],
+        text: "Which option?",
+      }),
+    ];
+    const msgs = itemsToUIMessages(items);
+    expect(msgs[0].parts[1]).toMatchObject({
+      type: "dynamic-tool",
+      toolName: "askUserQuestion",
+      toolCallId: "tc1",
+      state: "input-available",
+    });
+    expect(msgs[0].parts[1]).not.toHaveProperty("output");
   });
 
   it("restores multiple tool groups interleaved with text", () => {
@@ -390,5 +410,56 @@ describe("buildSegments", () => {
         text: "Q: Approach\nA: Option A",
       });
     });
+  });
+});
+
+describe("derivePendingQuestion", () => {
+  const questions = [{ question: "Pick one", options: [{ label: "A" }, { label: "B" }] }];
+
+  function pendingAskMessage(id: string): CompilerUIMessage {
+    return {
+      id,
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Which option?" },
+        { type: "dynamic-tool", toolName: "askUserQuestion", toolCallId: "tc-ask", state: "input-available", input: { questions } } as CompilerUIMessage["parts"][number],
+      ],
+    };
+  }
+
+  it("returns the questions and toolCallId from a pending ask on the last assistant message", () => {
+    const result = derivePendingQuestion([pendingAskMessage("a1")]);
+    expect(result).toEqual({ questions, toolCallId: "tc-ask" });
+  });
+
+  it("finds a pending ask on a streamed static tool part", () => {
+    const msg: CompilerUIMessage = {
+      id: "a1",
+      role: "assistant",
+      parts: [
+        { type: "tool-askUserQuestion", toolCallId: "tc-2", state: "input-available", input: { questions } } as CompilerUIMessage["parts"][number],
+      ],
+    };
+    expect(derivePendingQuestion([msg])).toEqual({ questions, toolCallId: "tc-2" });
+  });
+
+  it("returns null when the ask has been answered", () => {
+    const msg: CompilerUIMessage = {
+      id: "a1",
+      role: "assistant",
+      parts: [
+        { type: "dynamic-tool", toolName: "askUserQuestion", toolCallId: "tc-ask", state: "output-available", input: { questions }, output: "{}" } as CompilerUIMessage["parts"][number],
+      ],
+    };
+    expect(derivePendingQuestion([msg])).toBeNull();
+  });
+
+  it("returns null when a later message follows the ask", () => {
+    const userMsg: CompilerUIMessage = { id: "u1", role: "user", parts: [{ type: "text", text: "answers" }] };
+    expect(derivePendingQuestion([pendingAskMessage("a1"), userMsg])).toBeNull();
+  });
+
+  it("returns null for empty conversations", () => {
+    expect(derivePendingQuestion([])).toBeNull();
   });
 });

--- a/app/components/conversation-helpers.ts
+++ b/app/components/conversation-helpers.ts
@@ -1,5 +1,28 @@
 import type { CompilerUIMessage } from "~/lib/chat-message";
+import type { PendingQuestionData } from "~/lib/tools/ask-user-question.server";
 import type { Item } from "~/lib/types";
+
+export interface PendingQuestionState {
+  questions: PendingQuestionData[];
+  toolCallId: string;
+}
+
+export function derivePendingQuestion(messages: CompilerUIMessage[]): PendingQuestionState | null {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "assistant") return null;
+  for (const part of last.parts) {
+    if (part.type === "tool-askUserQuestion" && part.state === "input-available") {
+      return { questions: part.input.questions, toolCallId: part.toolCallId };
+    }
+    if (part.type === "dynamic-tool" && part.toolName === "askUserQuestion" && part.state === "input-available") {
+      const input = part.input as { questions?: PendingQuestionData[] } | undefined;
+      if (input?.questions?.length) {
+        return { questions: input.questions, toolCallId: part.toolCallId };
+      }
+    }
+  }
+  return null;
+}
 
 export interface MessageItem {
   id: string;
@@ -37,7 +60,7 @@ export function itemsToUIMessages(dbItems: MessageItem[]): CompilerUIMessage[] {
       }
     } else if (item.role === "assistant") {
       const content = item.content as {
-        parts?: Array<{ type: string; text?: string; toolName?: string; toolCallId?: string; input?: unknown; output?: string; isError?: boolean }>;
+        parts?: Array<{ type: string; text?: string; toolName?: string; toolCallId?: string; input?: unknown; output?: string; isError?: boolean; pending?: boolean }>;
         text?: string;
         toolCalls?: Array<{ id: string; tool: string; input: unknown; result?: string }>;
       } | null;
@@ -56,9 +79,11 @@ export function itemsToUIMessages(dbItems: MessageItem[]): CompilerUIMessage[] {
               toolName: p.toolName,
               toolCallId: p.toolCallId || crypto.randomUUID(),
               input: p.input,
-              ...(p.isError
-                ? { state: "output-error", errorText: p.output || "" }
-                : { state: "output-available", output: p.output || "" }),
+              ...(p.pending
+                ? { state: "input-available" }
+                : p.isError
+                  ? { state: "output-error", errorText: p.output || "" }
+                  : { state: "output-available", output: p.output || "" }),
             } as CompilerUIMessage["parts"][number]);
           }
         }

--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -445,6 +445,39 @@ describe("api.agent action", () => {
       expect(parts.every((p) => p.type !== "tool-call" || p.toolName !== "askUserQuestion")).toBe(true);
     });
 
+    it("persists an unanswered askUserQuestion as a pending tool call", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: false,
+        responseMessage: {
+          parts: [
+            { type: "text", text: "Which option?" },
+            { type: "dynamic-tool", toolName: "askUserQuestion", toolCallId: "tc-ask", state: "input-available", input: { questions: [{ question: "Pick one", options: [{ label: "A" }] }] } },
+          ],
+        },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const contentUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).content !== undefined);
+      const content = (contentUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      const parts = content.parts as Array<Record<string, unknown>>;
+      expect(parts).toHaveLength(2);
+      expect(parts[1]).toMatchObject({
+        type: "tool-call",
+        toolName: "askUserQuestion",
+        toolCallId: "tc-ask",
+        pending: true,
+      });
+    });
+
     it("concatenates text parts into a flat text field", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -332,7 +332,7 @@ export async function action({ request }: Route.ActionArgs) {
 
         const parts: Array<
           | { type: "text"; text: string }
-          | { type: "tool-call"; toolName: string; toolCallId: string; input: unknown; output: string; isError?: true }
+          | { type: "tool-call"; toolName: string; toolCallId: string; input: unknown; output: string; isError?: true; pending?: true }
           | { type: "step-start" }
         > = [];
         for (const part of assistantMessage.parts) {
@@ -345,7 +345,19 @@ export async function action({ request }: Route.ActionArgs) {
           } else if (part.type === "dynamic-tool" || (part.type as string).startsWith("tool-")) {
             const tp = part as { toolName?: string; toolCallId?: string; input?: unknown; output?: unknown; errorText?: string; state?: string; type: string };
             const name = tp.toolName || tp.type.replace("tool-", "");
-            if (name === "askUserQuestion") continue;
+            if (name === "askUserQuestion") {
+              if (tp.state === "input-available") {
+                parts.push({
+                  type: "tool-call",
+                  toolName: name,
+                  toolCallId: tp.toolCallId || crypto.randomUUID(),
+                  input: tp.input,
+                  output: "",
+                  pending: true,
+                });
+              }
+              continue;
+            }
             if (tp.state === "input-streaming" || tp.state === "input-available") continue;
             if (tp.state === "output-error") {
               parts.push({


### PR DESCRIPTION
- Persist unanswered askUserQuestion tool calls as pending parts (previously excluded, so a reload mid-question lost the question card entirely)
- Rehydrate pending parts as input-available and derive the question card from the last assistant message, with the real toolCallId
- After reload, addToolOutput now attaches to the restored part and sendAutomaticallyWhen resumes the run, matching the documented client-tool flow
- Remove the dead initialPendingQuestion prop (no route ever passed it)