### PR TITLE
Default to Claude Opus 5 with server-side refusal fallbacks

### DIFF
--- a/app/lib/agent.server.ts
+++ b/app/lib/agent.server.ts
@@ -1,5 +1,5 @@
 import { getAIProviderConfig } from "./ai-provider.server";
-import { getAgentEffort, getModel, getToolConfig } from "./models.server";
+import { getAgentEffort, getAgentFallbacks, getModel, getToolConfig } from "./models.server";
 import { buildTools } from "./tools/index.server";
 import { buildSystemPrompt, COMPACTION_INSTRUCTIONS } from "./prompts.server";
 import { isSaas } from "./appMode.server";
@@ -73,6 +73,7 @@ export async function getAgentConfig(
     modelId,
     provider,
     effort: getAgentEffort(provider, modelId),
+    fallbacks: getAgentFallbacks(provider, modelId),
     tools,
     systemPrompt: buildSystemPrompt(allRepoInfo),
     promptCachingEnabled: aiProviderConfig?.promptCachingEnabled !== false,

--- a/app/lib/models.server.test.ts
+++ b/app/lib/models.server.test.ts
@@ -3,9 +3,17 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("~/lib/db/index.server", () => ({ db: {} }));
 vi.mock("~/lib/ai-provider.server", () => ({ getAIProviderConfig: vi.fn() }));
 
-import { getAgentEffort } from "./models.server";
+import { getAgentEffort, getAgentFallbacks, DEFAULT_MODEL_ID } from "./models.server";
 
 describe("getAgentEffort", () => {
+  it("returns xhigh for claude-opus-5 on anthropic", () => {
+    expect(getAgentEffort("anthropic", "claude-opus-5")).toBe("xhigh");
+  });
+
+  it("returns xhigh for the default model", () => {
+    expect(getAgentEffort("anthropic", DEFAULT_MODEL_ID)).toBe("xhigh");
+  });
+
   it("returns xhigh for claude-opus-4-8 on anthropic", () => {
     expect(getAgentEffort("anthropic", "claude-opus-4-8")).toBe("xhigh");
   });
@@ -28,5 +36,24 @@ describe("getAgentEffort", () => {
   it("returns undefined for bedrock regardless of model", () => {
     expect(getAgentEffort("bedrock", "claude-opus-4-8")).toBeUndefined();
     expect(getAgentEffort("bedrock", "anthropic.claude-opus-4-8")).toBeUndefined();
+  });
+});
+
+describe("getAgentFallbacks", () => {
+  it("returns default for claude-opus-5 on anthropic", () => {
+    expect(getAgentFallbacks("anthropic", "claude-opus-5")).toBe("default");
+  });
+
+  it("returns default for claude-fable-5 on anthropic", () => {
+    expect(getAgentFallbacks("anthropic", "claude-fable-5")).toBe("default");
+  });
+
+  it("returns undefined for models without server-side fallbacks", () => {
+    expect(getAgentFallbacks("anthropic", "claude-opus-4-8")).toBeUndefined();
+    expect(getAgentFallbacks("anthropic", "claude-sonnet-4-6")).toBeUndefined();
+  });
+
+  it("returns undefined for bedrock regardless of model", () => {
+    expect(getAgentFallbacks("bedrock", "claude-opus-5")).toBeUndefined();
   });
 });

--- a/app/lib/models.server.ts
+++ b/app/lib/models.server.ts
@@ -27,11 +27,21 @@ export function clearModelCache() {
   modelCache = null;
 }
 
-export const DEFAULT_MODEL_ID = "claude-opus-4-8";
+export const DEFAULT_MODEL_ID = "claude-opus-5";
 
 export const TITLE_MODEL_ID = "claude-sonnet-4-6";
 
 const FALLBACK_MODELS: ClaudeModel[] = [
+  {
+    id: "claude-opus-5",
+    displayName: "Claude Opus 5",
+    createdAt: "2026-07-24T00:00:00Z",
+  },
+  {
+    id: "claude-sonnet-5",
+    displayName: "Claude Sonnet 5",
+    createdAt: "2026-06-29T00:00:00Z",
+  },
   {
     id: "claude-opus-4-8",
     displayName: "Claude Opus 4.8",
@@ -400,7 +410,7 @@ export async function getToolConfig(organizationId: string): Promise<string[]> {
   return [...baseTools, ...mapped];
 }
 
-const XHIGH_EFFORT_MODELS = ["claude-opus-4-7", "claude-opus-4-8"];
+const XHIGH_EFFORT_MODELS = ["claude-opus-5", "claude-fable-5", "claude-sonnet-5", "claude-opus-4-7", "claude-opus-4-8"];
 
 export function getAgentEffort(
   provider: AIProvider,
@@ -411,6 +421,19 @@ export function getAgentEffort(
     (m) => modelId === m || modelId.startsWith(`${m}-`)
   );
   return supported ? "xhigh" : undefined;
+}
+
+const SERVER_FALLBACK_MODELS = ["claude-opus-5", "claude-fable-5"];
+
+export function getAgentFallbacks(
+  provider: AIProvider,
+  modelId: string
+): "default" | undefined {
+  if (provider !== "anthropic") return undefined;
+  const supported = SERVER_FALLBACK_MODELS.some(
+    (m) => modelId === m || modelId.startsWith(`${m}-`)
+  );
+  return supported ? "default" : undefined;
 }
 
 export async function getModel(

--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -1133,6 +1133,28 @@ describe("api.agent action", () => {
       expect(streamArgs.providerOptions.anthropic.contextManagement).toBeDefined();
     });
 
+    it("passes fallbacks from agent config to provider options", async () => {
+      getAgentConfig.mockResolvedValue({
+        model: "mock-model",
+        modelId: "claude-opus-5",
+        effort: "xhigh",
+        fallbacks: "default",
+        tools: {},
+        systemPrompt: "test system prompt",
+        compactionEnabled: true,
+      });
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const streamArgs = mockStreamText.mock.calls[0][0];
+      expect(streamArgs.providerOptions.anthropic.fallbacks).toBe("default");
+    });
+
     it("omits effort when agent config has none", async () => {
       getAgentConfig.mockResolvedValue({
         model: "mock-model",

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -213,7 +213,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const modelMessages = await convertToModelMessages(uiMessages, { ignoreIncompleteToolCalls: true });
 
-  const { model, effort, tools, systemPrompt, promptCachingEnabled, compactionEnabled, compactionInstructions } = await getAgentConfig(
+  const { model, effort, fallbacks, tools, systemPrompt, promptCachingEnabled, compactionEnabled, compactionInstructions } = await getAgentConfig(
     organizationId,
     conv[0].projectId,
     memberId,
@@ -270,6 +270,7 @@ export async function action({ request }: Route.ActionArgs) {
     providerOptions: {
       anthropic: {
         ...(effort ? { effort } : {}),
+        ...(fallbacks ? { fallbacks } : {}),
         ...(compactionEnabled
           ? {
               contextManagement: {


### PR DESCRIPTION
- DEFAULT_MODEL_ID claude-opus-4-8 → claude-opus-5 (same $5/$25 pricing, xhigh effort supported)
- Add Opus 5 / Sonnet 5 / Fable 5 to the xhigh effort list and the fallback model catalog
- Enable fallbacks: "default" on Anthropic-provider Opus 5 / Fable 5 chats, so safety-classifier refusals auto-reroute to Opus 4.8 instead of failing the turn