### PR TITLE
Generate titles with Haiku 4.5

### DIFF
--- a/app/lib/models.server.ts
+++ b/app/lib/models.server.ts
@@ -29,7 +29,7 @@ export function clearModelCache() {
 
 export const DEFAULT_MODEL_ID = "claude-opus-5";
 
-export const TITLE_MODEL_ID = "claude-sonnet-4-6";
+export const TITLE_MODEL_ID = "claude-haiku-4-5";
 
 const FALLBACK_MODELS: ClaudeModel[] = [
   {


### PR DESCRIPTION
- TITLE_MODEL_ID claude-sonnet-4-6 → claude-haiku-4-5 (5x cheaper, designed for simple tasks, no thinking default so the 50-token cap keeps working)
- Anthropic-provider path only; Bedrock titles still use the org default model