### PR TITLE
Abort in-flight sandbox commands when a chat is stopped

### DIFF
--- a/app/lib/e2b/sandbox-tools.server.test.ts
+++ b/app/lib/e2b/sandbox-tools.server.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("~/lib/db/index.server", () => ({ db: {} }));
+vi.mock("~/lib/db/schema", () => ({
+  repositories: {},
+  projectRepositories: {},
+}));
+vi.mock("~/lib/clone.server", () => ({
+  cloneRepository: vi.fn(),
+  clonePublicRepository: vi.fn(),
+  pullRepository: vi.fn(),
+  pullPublicRepository: vi.fn(),
+  repoExists: vi.fn(),
+}));
+vi.mock("~/lib/appMode.server", () => ({ isSaas: () => true }));
+vi.mock("~/lib/github.server", () => ({ getOrRefreshAccessToken: vi.fn() }));
+vi.mock("~/lib/projects.server", () => ({ getOrgRepos: vi.fn().mockResolvedValue([]) }));
+
+const executeRepoSync = vi.fn().mockResolvedValue("synced");
+vi.mock("~/lib/tools/repo-sync.server", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/tools/repo-sync.server")>()),
+  executeRepoSync: (...args: unknown[]) => executeRepoSync(...args),
+}));
+
+import type { Sandbox } from "@e2b/code-interpreter";
+import { buildSandboxTools } from "./sandbox-tools.server";
+
+interface MockHandle {
+  wait: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function mockSandbox(handle: MockHandle) {
+  return {
+    commands: { run: vi.fn().mockResolvedValue(handle) },
+    files: { read: vi.fn().mockResolvedValue("file content") },
+  } as unknown as Sandbox;
+}
+
+function buildTools(sandbox: Sandbox) {
+  return buildSandboxTools({
+    sandbox,
+    cwd: "/repos",
+    enabledTools: ["bash", "grep", "glob", "read"],
+    organizationId: "org-1",
+  });
+}
+
+function execOptions(abortSignal?: AbortSignal) {
+  return { toolCallId: "tc-1", messages: [], abortSignal } as never;
+}
+
+describe("buildSandboxTools abort handling", () => {
+  it("runs commands in the background and returns their output", async () => {
+    const handle: MockHandle = {
+      wait: vi.fn().mockResolvedValue({ stdout: "hello", stderr: "" }),
+      kill: vi.fn(),
+    };
+    const sandbox = mockSandbox(handle);
+    const tools = buildTools(sandbox);
+
+    const output = await tools.bash.execute!({ command: "echo hello", description: "greet" }, execOptions());
+
+    expect(output).toBe("hello");
+    expect(sandbox.commands.run).toHaveBeenCalledWith(
+      "echo hello",
+      expect.objectContaining({ background: true, cwd: "/repos" }),
+    );
+    expect(handle.kill).not.toHaveBeenCalled();
+  });
+
+  it("kills the running command when the signal aborts", async () => {
+    let killed = false;
+    let rejectWait: ((err: Error) => void) | null = null;
+    const handle: MockHandle = {
+      wait: vi.fn().mockImplementation(
+        () => new Promise((_, reject) => {
+          if (killed) {
+            reject(new Error("command killed"));
+            return;
+          }
+          rejectWait = reject;
+        }),
+      ),
+      kill: vi.fn().mockImplementation(async () => {
+        killed = true;
+        rejectWait?.(new Error("command killed"));
+        return true;
+      }),
+    };
+    const sandbox = mockSandbox(handle);
+    const tools = buildTools(sandbox);
+    const controller = new AbortController();
+
+    const pending = tools.bash.execute!(
+      { command: "sleep 100", description: "wait" },
+      execOptions(controller.signal),
+    );
+    controller.abort();
+    const output = await pending;
+
+    expect(handle.kill).toHaveBeenCalledOnce();
+    expect(output).toContain("Error:");
+  });
+
+  it("does not start a command when the signal is already aborted", async () => {
+    const handle: MockHandle = { wait: vi.fn(), kill: vi.fn() };
+    const sandbox = mockSandbox(handle);
+    const tools = buildTools(sandbox);
+    const controller = new AbortController();
+    controller.abort();
+
+    const output = await tools.bash.execute!(
+      { command: "echo hi", description: "greet" },
+      execOptions(controller.signal),
+    );
+
+    expect(sandbox.commands.run).not.toHaveBeenCalled();
+    expect(output).toContain("Error:");
+  });
+
+  it("passes the abort signal through to repoSync", async () => {
+    const handle: MockHandle = { wait: vi.fn(), kill: vi.fn() };
+    const sandbox = mockSandbox(handle);
+    const tools = buildTools(sandbox);
+    const controller = new AbortController();
+
+    await tools.repoSync.execute!({ repositories: [] }, execOptions(controller.signal));
+
+    expect(executeRepoSync).toHaveBeenCalledWith(
+      { repositories: [] },
+      expect.objectContaining({ signal: controller.signal, sandbox }),
+    );
+  });
+});

--- a/app/lib/e2b/sandbox-tools.server.ts
+++ b/app/lib/e2b/sandbox-tools.server.ts
@@ -14,17 +14,49 @@ function resolveSandboxPath(inputPath: string, cwd: string): string {
   return path.join(cwd, inputPath);
 }
 
+async function runSandboxCommand(
+  sandbox: Sandbox,
+  command: string,
+  opts: { timeoutMs: number; cwd?: string; abortSignal?: AbortSignal },
+): Promise<{ stdout: string; stderr: string }> {
+  opts.abortSignal?.throwIfAborted();
+
+  const handle = await sandbox.commands.run(command, {
+    timeoutMs: opts.timeoutMs,
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    background: true,
+  });
+
+  const onAbort = () => {
+    handle.kill().catch(() => {});
+  };
+  if (opts.abortSignal?.aborted) {
+    onAbort();
+  } else {
+    opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
+  }
+
+  try {
+    const result = await handle.wait();
+    return { stdout: result.stdout || "", stderr: result.stderr || "" };
+  } finally {
+    opts.abortSignal?.removeEventListener("abort", onAbort);
+  }
+}
+
 async function executeSandboxBash(
   args: { command: string; timeout?: number; description: string },
   sandbox: Sandbox,
   cwd: string,
+  abortSignal?: AbortSignal,
 ): Promise<string> {
   const timeout = args.timeout || DEFAULT_TIMEOUT;
 
   try {
-    const result = await sandbox.commands.run(args.command, {
+    const result = await runSandboxCommand(sandbox, args.command, {
       timeoutMs: timeout,
       cwd,
+      abortSignal,
     });
 
     let output = "";
@@ -48,7 +80,9 @@ async function executeSandboxRead(
   args: { filePath: string; offset?: number; limit?: number },
   sandbox: Sandbox,
   cwd: string,
+  abortSignal?: AbortSignal,
 ): Promise<string> {
+  abortSignal?.throwIfAborted();
   const filePath = resolveSandboxPath(args.filePath, cwd);
 
   try {
@@ -95,6 +129,7 @@ async function executeSandboxGrep(
   args: { pattern: string; path?: string; include?: string },
   sandbox: Sandbox,
   cwd: string,
+  abortSignal?: AbortSignal,
 ): Promise<string> {
   const searchPath = args.path
     ? resolveSandboxPath(args.path, cwd)
@@ -105,7 +140,10 @@ async function executeSandboxGrep(
   rgArgs.push(shellEscape(args.pattern), shellEscape(searchPath));
 
   try {
-    const result = await sandbox.commands.run(rgArgs.join(" "), { timeoutMs: 30_000 });
+    const result = await runSandboxCommand(sandbox, rgArgs.join(" "), {
+      timeoutMs: 30_000,
+      abortSignal,
+    });
     const stdout = result.stdout || "";
 
     if (!stdout.trim()) {
@@ -140,15 +178,17 @@ async function executeSandboxGlob(
   args: { pattern: string; path?: string },
   sandbox: Sandbox,
   cwd: string,
+  abortSignal?: AbortSignal,
 ): Promise<string> {
   const searchPath = args.path
     ? resolveSandboxPath(args.path, cwd)
     : cwd;
 
   try {
-    const result = await sandbox.commands.run(
+    const result = await runSandboxCommand(
+      sandbox,
       `rg --files --glob ${shellEscape(args.pattern)} ${shellEscape(searchPath)}`,
-      { timeoutMs: 30_000 },
+      { timeoutMs: 30_000, abortSignal },
     );
 
     const stdout = result.stdout || "";
@@ -181,24 +221,24 @@ export function buildSandboxTools(options: BuildSandboxToolsOptions) {
     grep: tool({
       description: grepDescription,
       inputSchema: grepParameters,
-      execute: async (args) => executeSandboxGrep(args, sandbox, cwd),
+      execute: async (args, { abortSignal }) => executeSandboxGrep(args, sandbox, cwd, abortSignal),
       toModelOutput: ({ output }) => truncateForModel(output, GREP_MAX_CHARS),
     }),
     glob: tool({
       description: globDescription,
       inputSchema: globParameters,
-      execute: async (args) => executeSandboxGlob(args, sandbox, cwd),
+      execute: async (args, { abortSignal }) => executeSandboxGlob(args, sandbox, cwd, abortSignal),
       toModelOutput: ({ output }) => truncateForModel(output, GLOB_MAX_CHARS),
     }),
     read: tool({
       description: readDescription,
       inputSchema: readParameters,
-      execute: async (args) => executeSandboxRead(args, sandbox, cwd),
+      execute: async (args, { abortSignal }) => executeSandboxRead(args, sandbox, cwd, abortSignal),
     }),
     bash: tool({
       description: bashDescription,
       inputSchema: bashParameters,
-      execute: async (args) => executeSandboxBash(args, sandbox, cwd),
+      execute: async (args, { abortSignal }) => executeSandboxBash(args, sandbox, cwd, abortSignal),
     }),
     askUserQuestion: tool({
       description: askUserQuestionDescription,
@@ -217,7 +257,8 @@ export function buildSandboxTools(options: BuildSandboxToolsOptions) {
   filtered.repoSync = tool({
     description: repoSyncDescription,
     inputSchema: repoSyncParameters,
-    execute: async (args) => executeRepoSync(args, repoSyncOptions),
+    execute: async (args, { abortSignal }) =>
+      executeRepoSync(args, { ...repoSyncOptions, signal: abortSignal }),
   });
 
   return filtered;


### PR DESCRIPTION
- Sandbox tools now receive the tool-execution abortSignal; commands run in background mode and get killed on abort instead of running to full timeout
- repoSync gets the signal too (its clone/pull path already supported one)
- Handles the abort-before-listener race; covered by new tests