### PR TITLE
Record cache read/write token detail in assistant stats

### DIFF
--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -1272,6 +1272,72 @@ describe("api.agent action", () => {
       const stats = content.stats as Record<string, number>;
       expect(stats.toolUses).toBe(2);
     });
+
+    it("accumulates token and cache detail across steps into stats", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const streamArgs = mockStreamText.mock.calls[0][0];
+      streamArgs.onStepEnd({
+        usage: { inputTokens: 1000, outputTokens: 50, inputTokenDetails: { cacheReadTokens: 800, cacheWriteTokens: 150 } },
+        toolCalls: [{ toolName: "read" }],
+      });
+      streamArgs.onStepEnd({
+        usage: { inputTokens: 1200, outputTokens: 80, inputTokenDetails: { cacheReadTokens: 1100, cacheWriteTokens: 0 } },
+        toolCalls: [],
+      });
+
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: false,
+        responseMessage: { parts: [{ type: "text", text: "Done." }] },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const contentUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).content !== undefined);
+      const content = (contentUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      expect(content.stats).toMatchObject({
+        tokens: 2330,
+        inputTokens: 2200,
+        outputTokens: 130,
+        cacheReadTokens: 1900,
+        cacheWriteTokens: 150,
+        toolUses: 1,
+      });
+    });
+
+    it("tolerates steps without inputTokenDetails", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const streamArgs = mockStreamText.mock.calls[0][0];
+      streamArgs.onStepEnd({ usage: { inputTokens: 10, outputTokens: 5 }, toolCalls: [] });
+
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: false,
+        responseMessage: { parts: [{ type: "text", text: "Done." }] },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const contentUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).content !== undefined);
+      const content = (contentUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      expect(content.stats).toMatchObject({
+        tokens: 15,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      });
+    });
   });
 
   describe("stream termination callbacks", () => {

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -233,6 +233,8 @@ export async function action({ request }: Route.ActionArgs) {
 
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
+  let totalCacheReadTokens = 0;
+  let totalCacheWriteTokens = 0;
   let toolUseCount = 0;
   let streamErrored = false;
   const startTime = Date.now();
@@ -299,6 +301,8 @@ export async function action({ request }: Route.ActionArgs) {
       if (usage) {
         totalInputTokens += usage.inputTokens || 0;
         totalOutputTokens += usage.outputTokens || 0;
+        totalCacheReadTokens += usage.inputTokenDetails?.cacheReadTokens || 0;
+        totalCacheWriteTokens += usage.inputTokenDetails?.cacheWriteTokens || 0;
       }
       if (toolCalls) {
         for (const tc of toolCalls) {
@@ -328,6 +332,10 @@ export async function action({ request }: Route.ActionArgs) {
         const stats = {
           toolUses: toolUseCount,
           tokens: totalInputTokens + totalOutputTokens,
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          cacheReadTokens: totalCacheReadTokens,
+          cacheWriteTokens: totalCacheWriteTokens,
           durationMs,
         };
 
@@ -399,7 +407,7 @@ export async function action({ request }: Route.ActionArgs) {
           .set({ updatedAt: new Date() })
           .where(eq(conversations.id, conversationId));
 
-        console.log(`[agent] Stream ${status} for conversation=${conversationId} tokens=${stats.tokens} tools=${stats.toolUses} duration=${stats.durationMs}ms`);
+        console.log(`[agent] Stream ${status} for conversation=${conversationId} tokens=${stats.tokens} cacheRead=${stats.cacheReadTokens} cacheWrite=${stats.cacheWriteTokens} tools=${stats.toolUses} duration=${stats.durationMs}ms`);
       } catch (cleanupError) {
         console.error(`[agent] Cleanup error for conversation=${conversationId}:`, cleanupError);
       }


### PR DESCRIPTION
- Accumulate inputTokens/outputTokens plus inputTokenDetails cacheReadTokens/cacheWriteTokens per step and persist them in item stats
- stats.tokens keeps its existing meaning (analytics sums it in SQL); new fields are additive
- Stream completion log now includes cache read/write counts