### PR TITLE
Stop cache breakpoints accumulating across steps

### DIFF
--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -1077,6 +1077,45 @@ describe("api.agent action", () => {
       });
     });
 
+    it("strips cache breakpoints left on earlier messages by previous steps", async () => {
+      getAgentConfig.mockResolvedValue({
+        model: "mock-model",
+        modelId: "claude-sonnet-4-6",
+        tools: {},
+        systemPrompt: "test system prompt",
+        promptCachingEnabled: true,
+        compactionEnabled: true,
+      });
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const streamArgs = mockStreamText.mock.calls[0][0];
+      const stepMessages = [
+        { role: "user", content: "Hello" },
+        {
+          role: "user",
+          content: "Prior tail",
+          providerOptions: { anthropic: { cacheControl: { type: "ephemeral" }, other: "keep" } },
+        },
+        { role: "assistant", content: "Working on it" },
+        { role: "user", content: "Tool results" },
+      ];
+      const result = streamArgs.prepareStep({ messages: stepMessages });
+
+      const withBreakpoints = result.messages.filter(
+        (m: { providerOptions?: { anthropic?: { cacheControl?: unknown } } }) =>
+          m.providerOptions?.anthropic?.cacheControl !== undefined
+      );
+      expect(withBreakpoints).toHaveLength(1);
+      expect(result.messages[3].providerOptions.anthropic.cacheControl).toEqual({ type: "ephemeral" });
+      expect(result.messages[1].providerOptions.anthropic).toEqual({ other: "keep" });
+    });
+
 });
 
   describe("native compaction via contextManagement", () => {

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -256,17 +256,27 @@ export async function action({ request }: Route.ActionArgs) {
     tools,
     prepareStep: promptCachingEnabled
       ? ({ messages: stepMessages }) => ({
-          messages: stepMessages.map((msg, index) =>
-            index === stepMessages.length - 1
-              ? {
-                  ...msg,
-                  providerOptions: {
-                    ...msg.providerOptions,
-                    anthropic: { cacheControl: { type: "ephemeral" } },
-                  },
-                }
-              : msg
-          ),
+          messages: stepMessages.map((msg, index) => {
+            const { cacheControl: staleCacheControl, ...anthropicRest } =
+              (msg.providerOptions?.anthropic ?? {}) as Record<string, unknown>;
+            void staleCacheControl;
+            const isLast = index === stepMessages.length - 1;
+            const anthropic = isLast
+              ? { ...anthropicRest, cacheControl: { type: "ephemeral" } }
+              : anthropicRest;
+            const providerOptions = { ...msg.providerOptions } as Record<string, unknown>;
+            if (Object.keys(anthropic).length > 0) {
+              providerOptions.anthropic = anthropic;
+            } else {
+              delete providerOptions.anthropic;
+            }
+            return {
+              ...msg,
+              providerOptions: (Object.keys(providerOptions).length > 0
+                ? providerOptions
+                : undefined) as typeof msg.providerOptions,
+            };
+          }),
         })
       : undefined,
     providerOptions: {


### PR DESCRIPTION
- In v7, messages returned from prepareStep carry forward to later steps, so the per-step cacheControl stamp accumulated one breakpoint per step and blew the 4-breakpoint limit (seen as warnings in dev, found 5..10)
- prepareStep now strips stale breakpoints from earlier messages and marks only the current tail, preserving any other anthropic provider options