### PR TITLE
Retry Redis connections after a failed attempt

### DIFF
--- a/app/lib/resumable.server.ts
+++ b/app/lib/resumable.server.ts
@@ -38,6 +38,9 @@ export function getStreamContext(): ResumableStreamContext {
 function getRedis(): Promise<RedisClient> {
   if (!redisPromise) {
     redisPromise = connectRedis();
+    redisPromise.catch(() => {
+      redisPromise = null;
+    });
   }
   return redisPromise;
 }
@@ -104,6 +107,9 @@ function ensureStopSubscriber(): Promise<void> {
         abortLocal(conversationId);
       });
     })();
+    stopSubscriberPromise.catch(() => {
+      stopSubscriberPromise = null;
+    });
   }
   return stopSubscriberPromise;
 }


### PR DESCRIPTION
- A failed initial Redis connect cached the rejected promise forever, wedging resumable streams until restart; failed connection promises now reset so the next request retries