### PR TITLE
Persist assistant UIMessages verbatim

### DIFF
--- a/app/components/conversation-helpers.test.ts
+++ b/app/components/conversation-helpers.test.ts
@@ -463,3 +463,62 @@ describe("derivePendingQuestion", () => {
     expect(derivePendingQuestion([])).toBeNull();
   });
 });
+
+describe("verbatim uiParts persistence", () => {
+  it("prefers uiParts over the legacy parts shape", () => {
+    const uiParts = [
+      { type: "text", text: "Live shape" },
+      { type: "tool-read", toolCallId: "tc9", state: "output-available", input: { filePath: "/f" }, output: "data" },
+    ] as CompilerUIMessage["parts"];
+    const items = [
+      assistantItem("a1", {
+        parts: [{ type: "text", text: "Legacy shape" }],
+        text: "Legacy shape",
+        uiParts,
+      }),
+    ];
+    const msgs = itemsToUIMessages(items);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].parts).toEqual(uiParts);
+  });
+
+  it("falls back to the legacy shape when uiParts is empty", () => {
+    const items = [
+      assistantItem("a1", {
+        parts: [{ type: "text", text: "Legacy shape" }],
+        text: "Legacy shape",
+        uiParts: [],
+      }),
+    ];
+    const msgs = itemsToUIMessages(items);
+    expect(msgs[0].parts).toEqual([{ type: "text", text: "Legacy shape" }]);
+  });
+});
+
+describe("buildSegments with streamed static tool parts", () => {
+  it("groups tool-* parts and keeps text boundaries", () => {
+    const segments = buildSegments([
+      { type: "text", text: "Checking" },
+      { type: "tool-read", toolCallId: "t1", state: "output-available", input: {}, output: "a" },
+      { type: "tool-grep", toolCallId: "t2", state: "output-available", input: {}, output: "b" },
+      { type: "text", text: "Done" },
+    ] as CompilerUIMessage["parts"]);
+    expect(segments.map((s) => s.kind)).toEqual(["text", "tools", "text"]);
+    expect(segments[1].kind === "tools" ? segments[1].tools : []).toHaveLength(2);
+  });
+
+  it("extracts qa from a static tool-askUserQuestion part", () => {
+    const segments = buildSegments([
+      { type: "tool-askUserQuestion", toolCallId: "t1", state: "output-available", input: { questions: [] }, output: JSON.stringify({ Approach: "Option A" }) },
+    ] as CompilerUIMessage["parts"]);
+    expect(segments).toEqual([{ kind: "qa", text: "Q: Approach\nA: Option A" }]);
+  });
+
+  it("ignores reasoning parts", () => {
+    const segments = buildSegments([
+      { type: "reasoning", text: "" },
+      { type: "text", text: "Answer" },
+    ] as CompilerUIMessage["parts"]);
+    expect(segments).toEqual([{ kind: "text", text: "Answer" }]);
+  });
+});

--- a/app/components/conversation-helpers.ts
+++ b/app/components/conversation-helpers.ts
@@ -63,7 +63,17 @@ export function itemsToUIMessages(dbItems: MessageItem[]): CompilerUIMessage[] {
         parts?: Array<{ type: string; text?: string; toolName?: string; toolCallId?: string; input?: unknown; output?: string; isError?: boolean; pending?: boolean }>;
         text?: string;
         toolCalls?: Array<{ id: string; tool: string; input: unknown; result?: string }>;
+        uiParts?: CompilerUIMessage["parts"];
       } | null;
+
+      if (content?.uiParts && content.uiParts.length > 0) {
+        messages.push({
+          id: item.id,
+          role: "assistant",
+          parts: content.uiParts,
+        });
+        continue;
+      }
 
       const uiParts: CompilerUIMessage["parts"] = [];
 

--- a/app/routes/api.agent.test.ts
+++ b/app/routes/api.agent.test.ts
@@ -635,6 +635,37 @@ describe("api.agent action", () => {
       });
     });
 
+    it("persists verbatim uiParts and filters compaction blocks from them", async () => {
+      mockDb._selectResults = [
+        [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],
+        [],
+      ];
+      mockDb._selectCallCount = 0;
+      const request = buildRequest(validBody());
+      await callAction(request);
+
+      const compactionPart = {
+        type: "text",
+        text: "Summary of earlier work",
+        providerMetadata: { anthropic: { type: "compaction" } },
+      };
+      const reasoningPart = { type: "reasoning", text: "", providerOptions: { anthropic: { signature: "sig" } } };
+      const textPart = { type: "text", text: "Answer." };
+      const toolPart = { type: "tool-read", toolCallId: "tc-1", state: "output-available", input: { filePath: "/f" }, output: "data" };
+
+      const callArgs = mockToUIMessageStream.mock.calls[0][0];
+      await callArgs.onEnd({
+        isAborted: false,
+        responseMessage: { parts: [compactionPart, reasoningPart, textPart, toolPart] },
+      });
+
+      const setCalls = mockDb._updateSet.mock.calls;
+      const contentUpdate = setCalls.find((c: unknown[]) => (c[0] as Record<string, unknown>).content !== undefined);
+      const content = (contentUpdate![0] as Record<string, unknown>).content as Record<string, unknown>;
+      expect(content.uiParts).toEqual([reasoningPart, textPart, toolPart]);
+      expect(content.text).toBe("Answer.");
+    });
+
     it("skips tool calls that never reached a terminal state", async () => {
       mockDb._selectResults = [
         [{ id: "conv-1", title: "Existing Chat", userId: "user-1" }],

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -212,14 +212,14 @@ export async function action({ request }: Route.ActionArgs) {
     }
   }
 
-  const modelMessages = await convertToModelMessages(uiMessages, { ignoreIncompleteToolCalls: true });
-
   const { model, effort, fallbacks, tools, systemPrompt, promptCachingEnabled, compactionEnabled, compactionInstructions } = await getAgentConfig(
     organizationId,
     conv[0].projectId,
     memberId,
     request.signal,
   );
+
+  const modelMessages = await convertToModelMessages(uiMessages, { ignoreIncompleteToolCalls: true, tools });
 
   const assistantItemId = crypto.randomUUID();
   await db.insert(items).values({
@@ -409,10 +409,15 @@ export async function action({ request }: Route.ActionArgs) {
           .map((p) => p.text)
           .join("");
 
+        const uiParts = assistantMessage.parts.filter((part) => {
+          const meta = (part as { providerMetadata?: { anthropic?: { type?: string } } }).providerMetadata;
+          return meta?.anthropic?.type !== "compaction";
+        });
+
         await db
           .update(items)
           .set({
-            content: { parts, text, stats },
+            content: { parts, text, stats, uiParts },
             status,
           })
           .where(eq(items.id, assistantItemId));


### PR DESCRIPTION
- Store the stream's final UIMessage parts (uiParts) alongside the legacy shape; rehydration prefers them, old rows fall back unchanged
- Reloaded conversations now carry the same static tool parts and states as live streams (one rendering path), and reasoning parts round-trip for same-model replay
- Pass tools to convertToModelMessages so rebuilt prompts apply toModelOutput truncation exactly like the live loop, moving cross-turn prompts toward byte-identical for cache hits
- Compaction blocks stay filtered from persistence