### PR TITLE
Cache model lists per organization

### DIFF
--- a/app/lib/models.server.test.ts
+++ b/app/lib/models.server.test.ts
@@ -1,9 +1,49 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("~/lib/db/index.server", () => ({ db: {} }));
-vi.mock("~/lib/ai-provider.server", () => ({ getAIProviderConfig: vi.fn() }));
 
-import { getAgentEffort, getAgentFallbacks, DEFAULT_MODEL_ID } from "./models.server";
+const getAIProviderConfig = vi.fn();
+vi.mock("~/lib/ai-provider.server", () => ({
+  getAIProviderConfig: (...args: unknown[]) => getAIProviderConfig(...args),
+}));
+
+import { getAgentEffort, getAgentFallbacks, getAvailableClaudeModels, clearModelCache, DEFAULT_MODEL_ID } from "./models.server";
+
+describe("getAvailableClaudeModels caching", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    clearModelCache();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({
+        data: [{ id: "claude-opus-5", display_name: "Claude Opus 5", created_at: "2026-07-24T00:00:00Z" }],
+      })),
+    );
+    getAIProviderConfig.mockImplementation(async (organizationId: string) => ({
+      provider: "anthropic",
+      anthropicApiKey: `key-${organizationId}`,
+    }));
+  });
+
+  it("caches per organization instead of a single slot", async () => {
+    await getAvailableClaudeModels("org-1");
+    await getAvailableClaudeModels("org-2");
+    await getAvailableClaudeModels("org-1");
+    await getAvailableClaudeModels("org-2");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches after clearModelCache", async () => {
+    await getAvailableClaudeModels("org-1");
+    clearModelCache();
+    await getAvailableClaudeModels("org-1");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe("getAgentEffort", () => {
   it("returns xhigh for claude-opus-5 on anthropic", () => {

--- a/app/lib/models.server.ts
+++ b/app/lib/models.server.ts
@@ -13,18 +13,16 @@ export interface ClaudeModel {
   createdAt: string;
 }
 
-interface ModelCache {
+interface ModelCacheEntry {
   models: ClaudeModel[];
   fetchedAt: number;
-  provider: string;
-  organizationId: string;
 }
 
-let modelCache: ModelCache | null = null;
+const modelCache = new Map<string, ModelCacheEntry>();
 const CACHE_TTL = 60 * 60 * 1000;
 
 export function clearModelCache() {
-  modelCache = null;
+  modelCache.clear();
 }
 
 export const DEFAULT_MODEL_ID = "claude-opus-5";
@@ -258,13 +256,10 @@ export async function getAvailableClaudeModels(
   }
 
   const now = Date.now();
-  if (
-    modelCache &&
-    modelCache.organizationId === organizationId &&
-    modelCache.provider === config.provider &&
-    now - modelCache.fetchedAt < CACHE_TTL
-  ) {
-    return modelCache.models;
+  const cacheKey = `${organizationId}:${config.provider}`;
+  const cached = modelCache.get(cacheKey);
+  if (cached && now - cached.fetchedAt < CACHE_TTL) {
+    return cached.models;
   }
 
   let models: ClaudeModel[];
@@ -286,12 +281,7 @@ export async function getAvailableClaudeModels(
     return FALLBACK_MODELS;
   }
 
-  modelCache = {
-    models,
-    fetchedAt: now,
-    provider: config.provider,
-    organizationId,
-  };
+  modelCache.set(cacheKey, { models, fetchedAt: now });
 
   return models;
 }


### PR DESCRIPTION
- The model list cache was a single slot, so on multi-tenant SaaS every org evicted the previous org's entry and the 1h TTL never took effect
- Now a Map keyed by org+provider; clearModelCache clears all entries as before