### PR TITLE
Fail clearly when no AI provider is configured

### DIFF
--- a/app/lib/models.server.test.ts
+++ b/app/lib/models.server.test.ts
@@ -7,7 +7,18 @@ vi.mock("~/lib/ai-provider.server", () => ({
   getAIProviderConfig: (...args: unknown[]) => getAIProviderConfig(...args),
 }));
 
-import { getAgentEffort, getAgentFallbacks, getAvailableClaudeModels, clearModelCache, DEFAULT_MODEL_ID } from "./models.server";
+import { getAgentEffort, getAgentFallbacks, getAvailableClaudeModels, getTitleGenerationModel, clearModelCache, DEFAULT_MODEL_ID } from "./models.server";
+
+describe("unconfigured provider", () => {
+  it("throws a clear error instead of using an empty API key", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    getAIProviderConfig.mockResolvedValue(null);
+
+    await expect(getTitleGenerationModel("org-1")).rejects.toThrow(/AI provider is not configured/);
+
+    vi.unstubAllEnvs();
+  });
+});
 
 describe("getAvailableClaudeModels caching", () => {
   const fetchMock = vi.fn();

--- a/app/lib/models.server.ts
+++ b/app/lib/models.server.ts
@@ -413,6 +413,16 @@ export function getAgentEffort(
   return supported ? "xhigh" : undefined;
 }
 
+function requireAnthropicApiKey(config: { anthropicApiKey?: string } | null): string {
+  const apiKey = config?.anthropicApiKey || process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "AI provider is not configured. Add an Anthropic API key or Bedrock credentials in Settings → AI Provider."
+    );
+  }
+  return apiKey;
+}
+
 const SERVER_FALLBACK_MODELS = ["claude-opus-5", "claude-fable-5"];
 
 export function getAgentFallbacks(
@@ -443,7 +453,7 @@ export async function getModel(
   }
 
   const anthropic = createAnthropic({
-    apiKey: config?.anthropicApiKey || process.env.ANTHROPIC_API_KEY || "",
+    apiKey: requireAnthropicApiKey(config),
   });
   return { model: anthropic(modelId), modelId };
 }
@@ -469,7 +479,7 @@ export async function getTitleGenerationModel(
   }
 
   const anthropic = createAnthropic({
-    apiKey: config?.anthropicApiKey || process.env.ANTHROPIC_API_KEY || "",
+    apiKey: requireAnthropicApiKey(config),
   });
   return anthropic(TITLE_MODEL_ID);
 }


### PR DESCRIPTION
- An unconfigured org previously constructed the Anthropic provider with an empty API key, surfacing as a cryptic 401 at call time
- getModel/getTitleGenerationModel now throw "AI provider is not configured..." pointing at Settings → AI Provider