### PR TITLE
Wire the web search and fetch toggles to Anthropic server-side tools

### DIFF
--- a/app/components/agent-conversation.tsx
+++ b/app/components/agent-conversation.tsx
@@ -692,6 +692,21 @@ const AssistantMessageRow = memo(function AssistantMessageRow({ message, isStrea
       .join("\n\n"),
     [segments],
   );
+
+  const sources = useMemo(() => {
+    const seen = new Set<string>();
+    const list: Array<{ url: string; title?: string | null }> = [];
+    for (const part of message.parts) {
+      if (part.type === "source-url") {
+        const sp = part as { url: string; title?: string | null };
+        if (sp.url && !seen.has(sp.url)) {
+          seen.add(sp.url);
+          list.push({ url: sp.url, title: sp.title });
+        }
+      }
+    }
+    return list;
+  }, [message.parts]);
   const hasContent = allText.trim().length > 0;
   const hasAnything = segments.length > 0;
 
@@ -771,6 +786,25 @@ const AssistantMessageRow = memo(function AssistantMessageRow({ message, isStrea
         }
         return null;
       })}
+
+      {sources.length > 0 && (
+        <div className="mt-2 text-xs text-neutral-400 dark:text-neutral-500">
+          Sources:{" "}
+          {sources.map((source, i) => (
+            <span key={source.url}>
+              {i > 0 && " · "}
+              <a
+                href={source.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-neutral-600 dark:hover:text-neutral-300"
+              >
+                {sourceLabel(source.url, source.title)}
+              </a>
+            </span>
+          ))}
+        </div>
+      )}
 
       {hasContent && (
         <div className="flex mt-1">
@@ -1161,7 +1195,20 @@ function getToolLabel(tool?: string): string {
       return "Running";
     case "repoSync":
       return "Fetching code";
+    case "web_search":
+      return "Searching the web";
+    case "web_fetch":
+      return "Reading a page";
     default:
       return "Running";
+  }
+}
+
+function sourceLabel(url: string, title?: string | null): string {
+  if (title) return title;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
   }
 }

--- a/app/lib/agent.server.ts
+++ b/app/lib/agent.server.ts
@@ -1,6 +1,7 @@
 import { getAIProviderConfig } from "./ai-provider.server";
 import { getAgentEffort, getAgentFallbacks, getModel, getToolConfig } from "./models.server";
 import { buildTools } from "./tools/index.server";
+import { buildWebTools } from "./tools/web.server";
 import { buildSystemPrompt, COMPACTION_INSTRUCTIONS } from "./prompts.server";
 import { isSaas } from "./appMode.server";
 import { getOrCreateSandbox } from "./e2b/sandbox-manager.server";
@@ -67,6 +68,8 @@ export async function getAgentConfig(
       projectId,
     });
   }
+
+  Object.assign(tools, buildWebTools(provider, modelId, enabledTools));
 
   return {
     model,

--- a/app/lib/models.server.ts
+++ b/app/lib/models.server.ts
@@ -3,6 +3,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createAmazonBedrockAnthropic } from "@ai-sdk/amazon-bedrock/anthropic";
 import type { LanguageModel } from "ai";
 import { getAIProviderConfig, type AIProvider } from "./ai-provider.server";
+import { isSaas } from "./appMode.server";
 import { db } from "./db/index.server";
 import { aiProviderConfigurations, members } from "./db/schema";
 import { eq } from "drizzle-orm";
@@ -393,7 +394,9 @@ export async function getToolConfig(organizationId: string): Promise<string[]> {
   const optionalTools =
     result.length > 0 && result[0].allowedTools
       ? (result[0].allowedTools as string[])
-      : ["Bash"];
+      : isSaas()
+        ? ["Bash", "WebFetch", "WebSearch"]
+        : ["Bash"];
 
   const mapped = optionalTools.map((t) => TOOL_NAME_MAP[t] || t.toLowerCase());
 

--- a/app/lib/tools/web.server.test.ts
+++ b/app/lib/tools/web.server.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { buildWebTools } from "./web.server";
+
+const ALL_ENABLED = ["read", "bash", "websearch", "webfetch"];
+
+function toolId(tool: unknown): string {
+  return (tool as { id: string }).id;
+}
+
+describe("buildWebTools", () => {
+  it("returns nothing for the bedrock provider", () => {
+    expect(buildWebTools("bedrock", "claude-opus-5", ALL_ENABLED)).toEqual({});
+  });
+
+  it("returns nothing when neither web tool is enabled", () => {
+    expect(buildWebTools("anthropic", "claude-opus-5", ["read", "bash"])).toEqual({});
+  });
+
+  it("builds only the enabled web tools", () => {
+    const tools = buildWebTools("anthropic", "claude-opus-5", ["websearch"]);
+    expect(Object.keys(tools)).toEqual(["web_search"]);
+  });
+
+  it("uses the modern variants on current-generation models", () => {
+    const tools = buildWebTools("anthropic", "claude-opus-5", ALL_ENABLED);
+    expect(toolId(tools.web_search)).toContain("20260209");
+    expect(toolId(tools.web_fetch)).toContain("20260209");
+  });
+
+  it("uses the modern variants for dated snapshot ids", () => {
+    const tools = buildWebTools("anthropic", "claude-sonnet-4-6-20260217", ALL_ENABLED);
+    expect(toolId(tools.web_search)).toContain("20260209");
+  });
+
+  it("falls back to the basic variants on older models", () => {
+    const tools = buildWebTools("anthropic", "claude-sonnet-4-5-20250929", ALL_ENABLED);
+    expect(toolId(tools.web_search)).toContain("20250305");
+    expect(toolId(tools.web_fetch)).toContain("20250910");
+  });
+});

--- a/app/lib/tools/web.server.ts
+++ b/app/lib/tools/web.server.ts
@@ -1,0 +1,49 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import type { Tool } from "ai";
+
+const anthropicTools = anthropic.tools;
+
+type AnyTool = Tool<any, any>;
+
+const MODERN_WEB_TOOL_MODELS = [
+  "claude-opus-5",
+  "claude-fable-5",
+  "claude-sonnet-5",
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+];
+
+const MAX_USES = 10;
+
+function supportsModernWebTools(modelId: string): boolean {
+  return MODERN_WEB_TOOL_MODELS.some((m) => modelId === m || modelId.startsWith(`${m}-`));
+}
+
+export function buildWebTools(
+  provider: string,
+  modelId: string,
+  enabledTools: string[],
+): Record<string, AnyTool> {
+  if (provider !== "anthropic") {
+    return {};
+  }
+
+  const modern = supportsModernWebTools(modelId);
+  const tools: Record<string, AnyTool> = {};
+
+  if (enabledTools.includes("websearch")) {
+    tools.web_search = modern
+      ? anthropicTools.webSearch_20260209({ maxUses: MAX_USES })
+      : anthropicTools.webSearch_20250305({ maxUses: MAX_USES });
+  }
+
+  if (enabledTools.includes("webfetch")) {
+    tools.web_fetch = modern
+      ? anthropicTools.webFetch_20260209({ maxUses: MAX_USES })
+      : anthropicTools.webFetch_20250910({ maxUses: MAX_USES });
+  }
+
+  return tools;
+}

--- a/app/routes/api.agent.ts
+++ b/app/routes/api.agent.ts
@@ -339,6 +339,7 @@ export async function action({ request }: Route.ActionArgs) {
     stream: result.stream,
     tools,
     originalMessages: uiMessages,
+    sendSources: true,
     sendFinish: false,
     onEnd: async ({ responseMessage: assistantMessage, isAborted }) => {
       try {

--- a/app/routes/settings.ai-provider.tsx
+++ b/app/routes/settings.ai-provider.tsx
@@ -29,10 +29,12 @@ import { isSaas } from "~/lib/appMode.server";
 const REQUIRED_TOOLS = ["Read", "Glob", "Grep", "Task"];
 
 const OPTIONAL_TOOLS = [
-  { id: "bash", label: "Bash", description: "Execute shell commands" },
-  { id: "webfetch", label: "WebFetch", description: "Fetch web page content" },
-  { id: "websearch", label: "WebSearch", description: "Search the web" },
+  { id: "bash", label: "Bash", description: "Execute shell commands", anthropicOnly: false },
+  { id: "webfetch", label: "WebFetch", description: "Fetch web page content", anthropicOnly: true },
+  { id: "websearch", label: "WebSearch", description: "Search the web", anthropicOnly: true },
 ];
+
+const ANTHROPIC_ONLY_TOOL_IDS = OPTIONAL_TOOLS.filter((t) => t.anthropicOnly).map((t) => t.id);
 
 interface ModelOption {
   id: string;
@@ -110,9 +112,10 @@ export async function action({ request }: Route.ActionArgs) {
 
   if (intent === "save-tools") {
     const selectedTools = formData.getAll("selectedTools") as string[];
-    const validTools = selectedTools.filter((t) =>
-      SERVER_OPTIONAL_TOOLS.some((ot) => ot.id === t)
-    );
+    const providerConfig = await getAIProviderConfig(user.organization.id);
+    const validTools = selectedTools
+      .filter((t) => SERVER_OPTIONAL_TOOLS.some((ot) => ot.id === t))
+      .filter((t) => providerConfig?.provider !== "bedrock" || !ANTHROPIC_ONLY_TOOL_IDS.includes(t));
     await saveToolConfig(user.organization.id, validTools);
     await logAuditEvent(user.organization.id, user.id, "updated tool configuration");
     return { error: null, success: true, intent };
@@ -620,29 +623,37 @@ export default function AIProviderSettings({ loaderData }: Route.ComponentProps)
                   Optional tools:
                 </p>
                 <div className="space-y-2">
-                  {OPTIONAL_TOOLS.map((tool) => (
-                    <label
-                      key={tool.id}
-                      className="flex items-center gap-3 p-3 border border-neutral-200 dark:border-neutral-600 rounded-lg cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
-                    >
-                      <input
-                        type="checkbox"
-                        name="selectedTools"
-                        value={tool.id}
-                        checked={selectedTools.includes(tool.id)}
-                        onChange={() => handleToolToggle(tool.id)}
-                        className="w-4 h-4"
-                      />
-                      <div className="flex-1">
-                        <span className="font-medium text-neutral-900 dark:text-neutral-100">
-                          {tool.label}
-                        </span>
-                        <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                          {tool.description}
-                        </p>
-                      </div>
-                    </label>
-                  ))}
+                  {OPTIONAL_TOOLS.map((tool) => {
+                    const unavailable = tool.anthropicOnly && config.provider === "bedrock";
+                    return (
+                      <label
+                        key={tool.id}
+                        className={`flex items-center gap-3 p-3 border border-neutral-200 dark:border-neutral-600 rounded-lg transition-colors ${
+                          unavailable
+                            ? "opacity-50 cursor-not-allowed"
+                            : "cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-700"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          name="selectedTools"
+                          value={tool.id}
+                          checked={!unavailable && selectedTools.includes(tool.id)}
+                          disabled={unavailable}
+                          onChange={() => handleToolToggle(tool.id)}
+                          className="w-4 h-4"
+                        />
+                        <div className="flex-1">
+                          <span className="font-medium text-neutral-900 dark:text-neutral-100">
+                            {tool.label}
+                          </span>
+                          <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                            {unavailable ? "Not available with AWS Bedrock" : tool.description}
+                          </p>
+                        </div>
+                      </label>
+                    );
+                  })}
                 </div>
               </div>
 


### PR DESCRIPTION
- The WebSearch/WebFetch settings toggles existed but were silently dropped by the tool builders — enabling them did nothing (regression from the Feb agent-sdk migration)
- They now add Anthropic's server-side web_search/web_fetch provider tools (modern 20260209 variants on current models, basic variants on older ones); Anthropic executes them, no scraping infra
- SaaS orgs without a provider config row get web tools enabled by default (their toggle save was a no-op UPDATE; self-hosted defaults unchanged)
- Bedrock orgs cannot enable them: checkboxes disabled with a "Not available with AWS Bedrock" note, rejected server-side on save, and the tool builder skips them regardless
- Assistant messages render a Sources footer from streamed source parts (sendSources on), with searching/fetching activity labels